### PR TITLE
feat: add lookup2 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/murmur.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/murmur.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Hash Library (hashlib)
 
-A PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, and CityHash128 algorithms.
+A PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, and lookup2 algorithms.
 
 ## Table of Contents
 
@@ -21,6 +21,7 @@ A PostgreSQL extension providing high-performance hash functions for data proces
    - [crc32](#crc32)
    - [cityhash64](#cityhash64)
    - [cityhash128](#cityhash128)
+   - [lookup2](#lookup2)
    - [Common Use Cases](#common-use-cases)
      - [Data Partitioning](#data-partitioning)
      - [Sampling](#sampling)
@@ -125,6 +126,7 @@ sudo make install PG_CONFIG=/path/to/pg_config
 - **CRC32**: Cyclic redundancy check algorithm for error detection
 - **CityHash64**: High-performance 64-bit hash function from Google
 - **CityHash128**: High-performance 128-bit hash function from Google
+- **lookup2**: Bob Jenkins' lookup2 hash function - fast and well-distributed
 - **Multiple Input Types**: Supports `text`, `bytea`, and `integer` inputs
 - **Custom Seed Support**: Optional seed parameter for hash customization
 - **High Performance**: Optimized C implementation
@@ -138,6 +140,7 @@ sudo make install PG_CONFIG=/path/to/pg_config
 | `crc32` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit CRC32 - cyclic redundancy check hash |
 | `cityhash64` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit CityHash - high-performance hash by Google |
 | `cityhash128` | `text`, `bytea`, `integer` | Yes | `bigint[]` | 128-bit CityHash - returns array of two 64-bit values |
+| `lookup2` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup2 - Bob Jenkins' hash function |
 
 ## Usage
 
@@ -332,6 +335,53 @@ SELECT
 
 </details>
 
+### lookup2
+
+lookup2 is Bob Jenkins' hash function, designed for fast hashing with good distribution properties.
+
+**Signatures:**
+- `lookup2(text)` → `integer`
+- `lookup2(text, integer)` → `integer`
+- `lookup2(bytea)` → `integer`
+- `lookup2(bytea, integer)` → `integer`
+- `lookup2(integer)` → `integer`
+- `lookup2(integer, integer)` → `integer`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Initial value/seed (default: 0)
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default initval (0)
+SELECT lookup2('hello world');
+-- Result: lookup2 hash of text
+
+-- Hash text with custom initval
+SELECT lookup2('hello world', 42);
+-- Result: lookup2 hash with custom initval
+
+-- Hash bytea data
+SELECT lookup2('hello world'::bytea);
+-- Result: lookup2 hash of bytea data
+
+-- Hash bytea with custom initval
+SELECT lookup2('hello world'::bytea, 42);
+-- Result: lookup2 hash with custom initval
+
+-- Hash integer values
+SELECT lookup2(12345);
+-- Result: lookup2 hash of integer
+
+-- Hash integer with custom initval
+SELECT lookup2(12345, 42);
+-- Result: lookup2 hash with custom initval
+```
+
+</details>
+
 ### Common Use Cases
 
 #### Data Partitioning
@@ -434,5 +484,6 @@ This project is licensed under the PostgreSQL License - see the [LICENSE](LICENS
 
 - MurmurHash3 algorithm by Austin Appleby
 - CityHash algorithm by Google Inc.
+- lookup2 algorithm by Bob Jenkins
 - PostgreSQL Extension Building Infrastructure (PGXS)
 - PostgreSQL Community for guidance and support

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PostgreSQL Hash Library (hashlib)
+# pghashlib - high performance hash functions for PostgreSQL
 
 A PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, and lookup2 algorithms.
 

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -144,3 +144,39 @@ CREATE OR REPLACE FUNCTION cityhash128(integer, bigint, bigint)
 RETURNS bigint[]
 AS 'MODULE_PATHNAME', 'cityhash128_int_seed'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup2 function for text (default initval = 0)
+CREATE OR REPLACE FUNCTION lookup2(text)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup2_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup2 function for text with custom initval
+CREATE OR REPLACE FUNCTION lookup2(text, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup2_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup2 function for bytea (default initval = 0)
+CREATE OR REPLACE FUNCTION lookup2(bytea)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup2_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup2 function for bytea with custom initval
+CREATE OR REPLACE FUNCTION lookup2(bytea, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup2_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup2 function for integer (default initval = 0)
+CREATE OR REPLACE FUNCTION lookup2(integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup2_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup2 function for integer with custom initval
+CREATE OR REPLACE FUNCTION lookup2(integer, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup2_int_seed'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/lookup2.c
+++ b/src/lookup2.c
@@ -1,0 +1,223 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+
+/*
+ * lookup2.c, by Bob Jenkins, December 1996, Public Domain.
+ * hash(), hash2(), hash3, and mix() are externally useful functions.
+ * Routines to test the hash are included if SELF_TEST is defined.
+ * You can use this free for any purpose.  It has no warranty.
+ *
+ * Adapted for PostgreSQL extension by adding PostgreSQL function wrappers.
+ */
+
+typedef uint32_t ub4;   /* unsigned 4-byte quantities */
+typedef uint8_t  ub1;   /* unsigned 1-byte quantities */
+
+#define hashsize(n) ((ub4)1<<(n))
+#define hashmask(n) (hashsize(n)-1)
+
+/*
+ * mix -- mix 3 32-bit values reversibly.
+ * For every delta with one or two bits set, and the deltas of all three
+ * high bits or all three low bits, whether the original value of a,b,c
+ * is almost all zero or is uniformly distributed,
+ * - If mix() is run forward or backward, at least 32 bits in a,b,c
+ *   have at least 1/4 probability of changing.
+ * - If mix() is run forward, every bit of c will change between 1/3 and
+ *   2/3 of the time.  (Well, 22/100 and 78/100 for some 2-bit deltas.)
+ * mix() was built using the well-known Fred Jenkins hash function.
+ */
+#define mix(a,b,c) \
+{ \
+  a -= b; a -= c; a ^= (c>>13); \
+  b -= c; b -= a; b ^= (a<<8); \
+  c -= a; c -= b; c ^= (b>>13); \
+  a -= b; a -= c; a ^= (c>>12);  \
+  b -= c; b -= a; b ^= (a<<16); \
+  c -= a; c -= b; c ^= (b>>5); \
+  a -= b; a -= c; a ^= (c>>3);  \
+  b -= c; b -= a; b ^= (a<<10); \
+  c -= a; c -= b; c ^= (b>>15); \
+}
+
+/*
+ * hash() -- hash a variable-length key into a 32-bit value
+ *   k       : the key (the unaligned variable-length array of bytes)
+ *   len     : the length of the key, counting by bytes
+ *   initval : can be any 4-byte value
+ * Returns a 32-bit value.  Every bit of the key affects every bit of
+ * the return value.  Every 1-bit and 2-bit delta achieves avalanche.
+ * About 36+6len instructions.
+ *
+ * The best hash table sizes are powers of 2.  There is no need to do
+ * mod a prime (mod is sooo slow!).  If you need less than 32 bits,
+ * use a bitmask.  For example, if you need only 10 bits, do
+ *   h = (h & hashmask(10));
+ * In which case, the hash table should have hashsize(10) elements.
+ *
+ * If you are hashing n strings (ub1 **)k, do it like this:
+ *   for (i=0, h=0; i<n; ++i) h = hash( k[i], len[i], h);
+ *
+ * By Bob Jenkins, 1996.  bob_jenkins@burtleburtle.net.  You may use this
+ * code any way you wish, private, educational, or commercial.  It's free.
+ *
+ * See http://burtleburtle.net/bob/hash/evahash.html
+ * Use for hash table lookup, or anything where one collision in 2^^32 is
+ * acceptable.  Do NOT use for cryptographic purposes.
+ */
+static ub4
+hash(const ub1 *k, ub4 length, ub4 initval)
+{
+   ub4 a, b, c, len;
+
+   /* Set up the internal state */
+   len = length;
+   a = b = 0x9e3779b9;  /* the golden ratio; an arbitrary value */
+   c = initval;         /* the previous hash value */
+
+   /*---------------------------------------- handle most of the key */
+   while (len >= 12)
+   {
+      a += (k[0] +((ub4)k[1]<<8) +((ub4)k[2]<<16) +((ub4)k[3]<<24));
+      b += (k[4] +((ub4)k[5]<<8) +((ub4)k[6]<<16) +((ub4)k[7]<<24));
+      c += (k[8] +((ub4)k[9]<<8) +((ub4)k[10]<<16)+((ub4)k[11]<<24));
+      mix(a,b,c);
+      k += 12; len -= 12;
+   }
+
+   /*------------------------------------- handle the last 11 bytes */
+   c += length;
+   switch(len)              /* all the case statements fall through */
+   {
+   case 11: c+=((ub4)k[10]<<24);
+   case 10: c+=((ub4)k[9]<<16);
+   case 9 : c+=((ub4)k[8]<<8);
+      /* the first byte of c is reserved for the length */
+   case 8 : b+=((ub4)k[7]<<24);
+   case 7 : b+=((ub4)k[6]<<16);
+   case 6 : b+=((ub4)k[5]<<8);
+   case 5 : b+=k[4];
+   case 4 : a+=((ub4)k[3]<<24);
+   case 3 : a+=((ub4)k[2]<<16);
+   case 2 : a+=((ub4)k[1]<<8);
+   case 1 : a+=k[0];
+     /* case 0: nothing left to add */
+   }
+   mix(a,b,c);
+   /*-------------------------------------------- report the result */
+   return c;
+}
+
+/* lookup2 for text input with default initval */
+PG_FUNCTION_INFO_V1(lookup2_text);
+
+Datum
+lookup2_text(PG_FUNCTION_ARGS)
+{
+    text *input;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_TEXT_PP(0);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hash((const ub1 *)data, len, 0);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup2 for text input with custom initval */
+PG_FUNCTION_INFO_V1(lookup2_text_seed);
+
+Datum
+lookup2_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input;
+    int32_t initval;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_TEXT_PP(0);
+    initval = PG_GETARG_INT32(1);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hash((const ub1 *)data, len, (uint32_t)initval);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup2 for bytea input with default initval */
+PG_FUNCTION_INFO_V1(lookup2_bytea);
+
+Datum
+lookup2_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_BYTEA_PP(0);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hash((const ub1 *)data, len, 0);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup2 for bytea input with custom initval */
+PG_FUNCTION_INFO_V1(lookup2_bytea_seed);
+
+Datum
+lookup2_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input;
+    int32_t initval;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_BYTEA_PP(0);
+    initval = PG_GETARG_INT32(1);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hash((const ub1 *)data, len, (uint32_t)initval);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup2 for integer input with default initval */
+PG_FUNCTION_INFO_V1(lookup2_int);
+
+Datum
+lookup2_int(PG_FUNCTION_ARGS)
+{
+    int32_t input;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_INT32(0);
+    hash_result = hash((const ub1 *)&input, sizeof(int32_t), 0);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup2 for integer input with custom initval */
+PG_FUNCTION_INFO_V1(lookup2_int_seed);
+
+Datum
+lookup2_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input, initval;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_INT32(0);
+    initval = PG_GETARG_INT32(1);
+    hash_result = hash((const ub1 *)&input, sizeof(int32_t), (uint32_t)initval);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}

--- a/src/lookup2.c
+++ b/src/lookup2.c
@@ -92,17 +92,17 @@ hash(const ub1 *k, ub4 length, ub4 initval)
    c += length;
    switch(len)              /* all the case statements fall through */
    {
-   case 11: c+=((ub4)k[10]<<24);
-   case 10: c+=((ub4)k[9]<<16);
-   case 9 : c+=((ub4)k[8]<<8);
+   case 11: c+=((ub4)k[10]<<24); __attribute__((fallthrough));
+   case 10: c+=((ub4)k[9]<<16); __attribute__((fallthrough));
+   case 9 : c+=((ub4)k[8]<<8); __attribute__((fallthrough));
       /* the first byte of c is reserved for the length */
-   case 8 : b+=((ub4)k[7]<<24);
-   case 7 : b+=((ub4)k[6]<<16);
-   case 6 : b+=((ub4)k[5]<<8);
-   case 5 : b+=k[4];
-   case 4 : a+=((ub4)k[3]<<24);
-   case 3 : a+=((ub4)k[2]<<16);
-   case 2 : a+=((ub4)k[1]<<8);
+   case 8 : b+=((ub4)k[7]<<24); __attribute__((fallthrough));
+   case 7 : b+=((ub4)k[6]<<16); __attribute__((fallthrough));
+   case 6 : b+=((ub4)k[5]<<8); __attribute__((fallthrough));
+   case 5 : b+=k[4]; __attribute__((fallthrough));
+   case 4 : a+=((ub4)k[3]<<24); __attribute__((fallthrough));
+   case 3 : a+=((ub4)k[2]<<16); __attribute__((fallthrough));
+   case 2 : a+=((ub4)k[1]<<8); __attribute__((fallthrough));
    case 1 : a+=k[0];
      /* case 0: nothing left to add */
    }

--- a/tests/expected/lookup2.out
+++ b/tests/expected/lookup2.out
@@ -1,0 +1,115 @@
+-- Test basic hash functionality with text
+SELECT lookup2('hello world');
+  lookup2  
+-----------
+ 447289830
+(1 row)
+
+-- Test hash with different text inputs
+SELECT lookup2('test string');
+  lookup2   
+------------
+ 1538088394
+(1 row)
+
+SELECT lookup2('another test');
+  lookup2   
+------------
+ 1074141746
+(1 row)
+
+-- Test text input with custom initval
+SELECT lookup2('hello world', 42);
+   lookup2   
+-------------
+ -1287150784
+(1 row)
+
+SELECT lookup2('hello world', 123);
+   lookup2   
+-------------
+ -1013821216
+(1 row)
+
+-- Test bytea input
+SELECT lookup2('hello world'::bytea);
+  lookup2  
+-----------
+ 447289830
+(1 row)
+
+-- Test bytea input with custom initval
+SELECT lookup2('hello world'::bytea, 42);
+   lookup2   
+-------------
+ -1287150784
+(1 row)
+
+-- Test integer input
+SELECT lookup2(12345);
+   lookup2   
+-------------
+ -1902978736
+(1 row)
+
+SELECT lookup2(-12345);
+  lookup2   
+------------
+ 1886942764
+(1 row)
+
+-- Test integer input with custom initval
+SELECT lookup2(12345, 42);
+  lookup2   
+------------
+ 1668431274
+(1 row)
+
+SELECT lookup2(-12345, 123);
+  lookup2   
+------------
+ 2032930975
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT lookup2('consistent test') = lookup2('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test initval effect (same input, different initvals should give different hashes)
+SELECT lookup2('initval test', 1) != lookup2('initval test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'lookup2'
+ORDER BY proname, proargtypes;
+ proname | provolatile | proisstrict 
+---------+-------------+-------------
+ lookup2 | i           | t
+ lookup2 | i           | t
+ lookup2 | i           | t
+ lookup2 | i           | t
+ lookup2 | i           | t
+ lookup2 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)

--- a/tests/expected/lookup2.out
+++ b/tests/expected/lookup2.out
@@ -113,3 +113,4 @@ WHERE extname = 'hashlib';
 ---------+------------
  hashlib | 0.0.1
 (1 row)
+

--- a/tests/sql/lookup2.sql
+++ b/tests/sql/lookup2.sql
@@ -1,0 +1,46 @@
+-- Test basic hash functionality with text
+SELECT lookup2('hello world');
+
+-- Test hash with different text inputs
+SELECT lookup2('test string');
+SELECT lookup2('another test');
+
+-- Test text input with custom initval
+SELECT lookup2('hello world', 42);
+SELECT lookup2('hello world', 123);
+
+-- Test bytea input
+SELECT lookup2('hello world'::bytea);
+
+-- Test bytea input with custom initval
+SELECT lookup2('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT lookup2(12345);
+SELECT lookup2(-12345);
+
+-- Test integer input with custom initval
+SELECT lookup2(12345, 42);
+SELECT lookup2(-12345, 123);
+
+-- Test consistency (same input should give same hash)
+SELECT lookup2('consistent test') = lookup2('consistent test');
+
+-- Test initval effect (same input, different initvals should give different hashes)
+SELECT lookup2('initval test', 1) != lookup2('initval test', 2);
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'lookup2'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Lookup2 hash function to hashlib extension with support for text, bytea, and integer inputs, including custom seed functionality