### PR TITLE
feat: add lookup3be 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/murmur.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/lookup3be.o src/murmur.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pghashlib - high performance hash functions for PostgreSQL
 
-A PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, and lookup2 algorithms.
+A PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, lookup2, and lookup3be algorithms.
 
 ## Table of Contents
 
@@ -22,6 +22,7 @@ A PostgreSQL extension providing high-performance hash functions for data proces
    - [cityhash64](#cityhash64)
    - [cityhash128](#cityhash128)
    - [lookup2](#lookup2)
+   - [lookup3be](#lookup3be)
    - [Common Use Cases](#common-use-cases)
      - [Data Partitioning](#data-partitioning)
      - [Sampling](#sampling)
@@ -127,6 +128,7 @@ sudo make install PG_CONFIG=/path/to/pg_config
 - **CityHash64**: High-performance 64-bit hash function from Google
 - **CityHash128**: High-performance 128-bit hash function from Google
 - **lookup2**: Bob Jenkins' lookup2 hash function - fast and well-distributed
+- **lookup3be**: Bob Jenkins' lookup3 hash function with big-endian byte order - improved version of lookup2
 - **Multiple Input Types**: Supports `text`, `bytea`, and `integer` inputs
 - **Custom Seed Support**: Optional seed parameter for hash customization
 - **High Performance**: Optimized C implementation
@@ -141,6 +143,7 @@ sudo make install PG_CONFIG=/path/to/pg_config
 | `cityhash64` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit CityHash - high-performance hash by Google |
 | `cityhash128` | `text`, `bytea`, `integer` | Yes | `bigint[]` | 128-bit CityHash - returns array of two 64-bit values |
 | `lookup2` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup2 - Bob Jenkins' hash function |
+| `lookup3be` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3be - Bob Jenkins' lookup3 with big-endian order |
 
 ## Usage
 
@@ -382,6 +385,53 @@ SELECT lookup2(12345, 42);
 
 </details>
 
+### lookup3be
+
+lookup3be is Bob Jenkins' lookup3 hash function with big-endian byte order, an improved version of lookup2 with better mixing and avalanche properties.
+
+**Signatures:**
+- `lookup3be(text)` → `integer`
+- `lookup3be(text, integer)` → `integer`
+- `lookup3be(bytea)` → `integer`
+- `lookup3be(bytea, integer)` → `integer`
+- `lookup3be(integer)` → `integer`
+- `lookup3be(integer, integer)` → `integer`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Initial value/seed (default: 0)
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default initval (0)
+SELECT lookup3be('hello world');
+-- Result: lookup3be hash of text
+
+-- Hash text with custom initval
+SELECT lookup3be('hello world', 42);
+-- Result: lookup3be hash with custom initval
+
+-- Hash bytea data
+SELECT lookup3be('hello world'::bytea);
+-- Result: lookup3be hash of bytea data
+
+-- Hash bytea with custom initval
+SELECT lookup3be('hello world'::bytea, 42);
+-- Result: lookup3be hash with custom initval
+
+-- Hash integer values
+SELECT lookup3be(12345);
+-- Result: lookup3be hash of integer
+
+-- Hash integer with custom initval
+SELECT lookup3be(12345, 42);
+-- Result: lookup3be hash with custom initval
+```
+
+</details>
+
 ### Common Use Cases
 
 #### Data Partitioning
@@ -484,6 +534,6 @@ This project is licensed under the PostgreSQL License - see the [LICENSE](LICENS
 
 - MurmurHash3 algorithm by Austin Appleby
 - CityHash algorithm by Google Inc.
-- lookup2 algorithm by Bob Jenkins
+- lookup2 and lookup3be algorithms by Bob Jenkins
 - PostgreSQL Extension Building Infrastructure (PGXS)
 - PostgreSQL Community for guidance and support

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -180,3 +180,39 @@ CREATE OR REPLACE FUNCTION lookup2(integer, integer)
 RETURNS integer
 AS 'MODULE_PATHNAME', 'lookup2_int_seed'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup3be function for text (default initval = 0)
+CREATE OR REPLACE FUNCTION lookup3be(text)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup3be_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup3be function for text with custom initval
+CREATE OR REPLACE FUNCTION lookup3be(text, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup3be_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup3be function for bytea (default initval = 0)
+CREATE OR REPLACE FUNCTION lookup3be(bytea)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup3be_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup3be function for bytea with custom initval
+CREATE OR REPLACE FUNCTION lookup3be(bytea, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup3be_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup3be function for integer (default initval = 0)
+CREATE OR REPLACE FUNCTION lookup3be(integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup3be_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- lookup3be function for integer with custom initval
+CREATE OR REPLACE FUNCTION lookup3be(integer, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lookup3be_int_seed'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/lookup3be.c
+++ b/src/lookup3be.c
@@ -1,0 +1,307 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+
+/*
+ * lookup3be.c, by Bob Jenkins, May 2006, Public Domain.
+ * 
+ * This is lookup3.c, but modified for big-endian byte order.
+ * 
+ * These are functions for producing 32-bit hashes for hash table lookup.
+ * hashword(), hashlittle(), hashlittle2(), hashbig(), mix(), and final() 
+ * are externally useful functions.  Routines to test the hash are included 
+ * if SELF_TEST is defined.  You can use this free for any purpose.  It's in
+ * the public domain.  It has no warranty.
+ *
+ * You probably want to use hashlittle().  hashlittle() and hashbig()
+ * hash byte arrays.  hashlittle() is is faster than hashbig() on
+ * little-endian machines.  Intel and AMD are little-endian machines.
+ * On second thought, you probably want hashlittle2(), which is identical to
+ * hashlittle() except it returns two 32-bit hashes for the price of one.  
+ * You could implement hashbig2() if you wanted but I haven't bothered here.
+ *
+ * If you want to find a hash of, say, exactly 7 integers, do
+ *   a = i1;  b = i2;  c = i3;
+ *   mix(a,b,c);
+ *   a += i4; b += i5; c += i6;
+ *   mix(a,b,c);
+ *   a += i7;
+ *   final(a,b,c);
+ * then use c as the hash value.  If you have a variable length array of
+ * 4-byte integers to hash, use hashword().  If you have a byte array (like
+ * a character string), use hashlittle().  If you have several byte arrays, or
+ * a mix of things, see the comments above hashlittle().  
+ *
+ * Why is this so big?  I read 12 bytes at a time into 3 4-byte integers, 
+ * then mix those integers.  This is fast (you can do a lot more thorough
+ * mixing than if you mix one byte at a time).  Second, the results of lots
+ * of hash functions are compared in hash.ps.  These hash functions do
+ * better than any other hash function I could find, and these hash functions
+ * are simple.  Third, these hash functions are designed to prevent malicious
+ * users from causing hash flooding.  See hash.doc.
+ *
+ * See http://burtleburtle.net/bob/c/lookup3.c for the original.
+ * Adapted for PostgreSQL extension by adding PostgreSQL function wrappers.
+ */
+
+#define hashsize(n) ((uint32_t)1<<(n))
+#define hashmask(n) (hashsize(n)-1)
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+/*
+ * mix -- mix 3 32-bit values reversibly.
+ *
+ * This is reversible, so any information in (a,b,c) before mix() is
+ * still in (a,b,c) after mix().
+ *
+ * If four pairs of (a,b,c) inputs are run through mix(), or through
+ * mix() in reverse, there are at least 32 bits of the output that
+ * are sometimes the same for one pair and different for another pair.
+ * This was tested for:
+ * * pairs that differed by one bit, by two bits, in any combination
+ *   of top bits of (a,b,c), or in any combination of bottom bits of
+ *   (a,b,c).
+ * * "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+ *   the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+ *   is commonly produced by subtraction) look like a single 1-bit
+ *   difference.
+ * * the base values were pseudorandom, all zero but one bit set, or 
+ *   all zero plus a counter, or all zero plus a counter plus a small
+ *   constant.
+ *
+ * Some k values for my "a-=c; a^=rot(c,k); c+=b;" arrangement that
+ * satisfy this are
+ *     4  6  8 16 19  4
+ *     9 15  3 18 27 15
+ *    14  9  3  7 17  3
+ * Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing
+ * for "differ" defined as + with a one-bit base and a two-bit delta.  I
+ * used http://burtleburtle.net/bob/hash/avalanche.html to choose 
+ * the operations, constants, and arrangements of the variables.
+ *
+ * This does not achieve avalanche.  There are input bits of (a,b,c)
+ * that fail to affect some output bits of (a,b,c), especially of a.  The
+ * most thoroughly mixed value is c, but it doesn't really even achieve
+ * avalanche in c.
+ *
+ * This allows some parallelism.  Read-after-writes are good at doubling
+ * the number of bits affected, so the goal of mixing pulls in the opposite
+ * direction as the goal of parallelism.  I did what I could.  Rotates
+ * seem to cost as much as shifts on every machine I could lay my hands
+ * on, and rotates are much kinder to the top and bottom bits, so I used
+ * rotates.
+ */
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+/*
+ * final -- final mixing of 3 32-bit values (a,b,c) into c
+ *
+ * Pairs of (a,b,c) values differing in only a few bits will usually
+ * produce values of c that look totally different.  This was tested for
+ * * pairs that differed by one bit, by two bits, in any combination
+ *   of top bits of (a,b,c), or in any combination of bottom bits of
+ *   (a,b,c).
+ * * "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+ *   the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+ *   is commonly produced by subtraction) look like a single 1-bit
+ *   difference.
+ * * the base values were pseudorandom, all zero but one bit set, or 
+ *   all zero plus a counter, or all zero plus a counter plus a small
+ *   constant.
+ *
+ * These constants passed:
+ *  14 11 25 16 4 14 24
+ *  12 14 25 16 4 14 24
+ * and these came close:
+ *   4  8 15 26 3 22 24
+ *  10  8 15 26 3 22 24
+ *  11  8 15 26 3 22 24
+ */
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+/*
+ * hashbig():
+ * This is the same as hashword() on big-endian machines.  It is different
+ * from hashlittle() on all machines.  hashbig() takes advantage of
+ * big-endian byte ordering. 
+ */
+static uint32_t hashbig( const void *key, size_t length, uint32_t initval)
+{
+  uint32_t a,b,c;
+  const uint8_t *k = (const uint8_t *)key;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef + ((uint32_t)length) + initval;
+
+  /*------------------------------------- handle most of the key */
+  while (length > 12)
+  {
+    a += ((uint32_t)k[0]<<24) + ((uint32_t)k[1]<<16) + ((uint32_t)k[2]<<8) + (uint32_t)k[3];
+    b += ((uint32_t)k[4]<<24) + ((uint32_t)k[5]<<16) + ((uint32_t)k[6]<<8) + (uint32_t)k[7];
+    c += ((uint32_t)k[8]<<24) + ((uint32_t)k[9]<<16) + ((uint32_t)k[10]<<8) + (uint32_t)k[11];
+    mix(a,b,c);
+    length -= 12;
+    k += 12;
+  }
+
+  /*-------------------------------- handle the last (incomplete) block */
+  /*
+   * "k[0]<<24" actually reads beyond the end of the string, but
+   * then shifts out the part it's not allowed to read.  Because the
+   * string is aligned, the illegal read is in the same word as the
+   * rest of the string.  Every machine with memory protection I've seen
+   * does it on word boundaries, so is OK with this.  But VALGRIND will
+   * still catch it and complain.  The masking trick does make the hash
+   * noticeable faster for short strings (like English words).
+   */
+  switch(length)
+  {
+  case 12: c += (uint32_t)k[11]; __attribute__((fallthrough));
+  case 11: c += ((uint32_t)k[10])<<8; __attribute__((fallthrough));
+  case 10: c += ((uint32_t)k[9])<<16; __attribute__((fallthrough));
+  case 9 : c += ((uint32_t)k[8])<<24; __attribute__((fallthrough));
+  case 8 : b += (uint32_t)k[7]; __attribute__((fallthrough));
+  case 7 : b += ((uint32_t)k[6])<<8; __attribute__((fallthrough));
+  case 6 : b += ((uint32_t)k[5])<<16; __attribute__((fallthrough));
+  case 5 : b += ((uint32_t)k[4])<<24; __attribute__((fallthrough));
+  case 4 : a += (uint32_t)k[3]; __attribute__((fallthrough));
+  case 3 : a += ((uint32_t)k[2])<<8; __attribute__((fallthrough));
+  case 2 : a += ((uint32_t)k[1])<<16; __attribute__((fallthrough));
+  case 1 : a += ((uint32_t)k[0])<<24;
+           break;
+  case 0 : return c;
+  }
+
+  final(a,b,c);
+  return c;
+}
+
+/* lookup3be for text input with default initval */
+PG_FUNCTION_INFO_V1(lookup3be_text);
+
+Datum
+lookup3be_text(PG_FUNCTION_ARGS)
+{
+    text *input;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_TEXT_PP(0);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hashbig(data, len, 0);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup3be for text input with custom initval */
+PG_FUNCTION_INFO_V1(lookup3be_text_seed);
+
+Datum
+lookup3be_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input;
+    int32_t initval;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_TEXT_PP(0);
+    initval = PG_GETARG_INT32(1);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hashbig(data, len, (uint32_t)initval);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup3be for bytea input with default initval */
+PG_FUNCTION_INFO_V1(lookup3be_bytea);
+
+Datum
+lookup3be_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_BYTEA_PP(0);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hashbig(data, len, 0);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup3be for bytea input with custom initval */
+PG_FUNCTION_INFO_V1(lookup3be_bytea_seed);
+
+Datum
+lookup3be_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input;
+    int32_t initval;
+    char *data;
+    int len;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_BYTEA_PP(0);
+    initval = PG_GETARG_INT32(1);
+    data = VARDATA_ANY(input);
+    len = VARSIZE_ANY_EXHDR(input);
+    hash_result = hashbig(data, len, (uint32_t)initval);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup3be for integer input with default initval */
+PG_FUNCTION_INFO_V1(lookup3be_int);
+
+Datum
+lookup3be_int(PG_FUNCTION_ARGS)
+{
+    int32_t input;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_INT32(0);
+    hash_result = hashbig(&input, sizeof(int32_t), 0);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}
+
+/* lookup3be for integer input with custom initval */
+PG_FUNCTION_INFO_V1(lookup3be_int_seed);
+
+Datum
+lookup3be_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input, initval;
+    uint32_t hash_result;
+    
+    input = PG_GETARG_INT32(0);
+    initval = PG_GETARG_INT32(1);
+    hash_result = hashbig(&input, sizeof(int32_t), (uint32_t)initval);
+    
+    PG_RETURN_INT32((int32_t)hash_result);
+}

--- a/tests/expected/lookup3be.out
+++ b/tests/expected/lookup3be.out
@@ -1,0 +1,116 @@
+-- Test basic hash functionality with text
+SELECT lookup3be('hello world');
+ lookup3be  
+------------
+ -942795449
+(1 row)
+
+-- Test hash with different text inputs
+SELECT lookup3be('test string');
+ lookup3be  
+------------
+ 1077573433
+(1 row)
+
+SELECT lookup3be('another test');
+  lookup3be  
+-------------
+ -2119669366
+(1 row)
+
+-- Test text input with custom initval
+SELECT lookup3be('hello world', 42);
+ lookup3be  
+------------
+ 1545643001
+(1 row)
+
+SELECT lookup3be('hello world', 123);
+ lookup3be  
+------------
+ 1709307537
+(1 row)
+
+-- Test bytea input
+SELECT lookup3be('hello world'::bytea);
+ lookup3be  
+------------
+ -942795449
+(1 row)
+
+-- Test bytea input with custom initval
+SELECT lookup3be('hello world'::bytea, 42);
+ lookup3be  
+------------
+ 1545643001
+(1 row)
+
+-- Test integer input
+SELECT lookup3be(12345);
+ lookup3be  
+------------
+ -185163110
+(1 row)
+
+SELECT lookup3be(-12345);
+  lookup3be  
+-------------
+ -1622048687
+(1 row)
+
+-- Test integer input with custom initval
+SELECT lookup3be(12345, 42);
+ lookup3be  
+------------
+ 1051714761
+(1 row)
+
+SELECT lookup3be(-12345, 123);
+ lookup3be  
+------------
+ 1268105482
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT lookup3be('consistent test') = lookup3be('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test initval effect (same input, different initvals should give different hashes)
+SELECT lookup3be('initval test', 1) != lookup3be('initval test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'lookup3be'
+ORDER BY proname, proargtypes;
+  proname  | provolatile | proisstrict 
+-----------+-------------+-------------
+ lookup3be | i           | t
+ lookup3be | i           | t
+ lookup3be | i           | t
+ lookup3be | i           | t
+ lookup3be | i           | t
+ lookup3be | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/sql/lookup3be.sql
+++ b/tests/sql/lookup3be.sql
@@ -1,0 +1,46 @@
+-- Test basic hash functionality with text
+SELECT lookup3be('hello world');
+
+-- Test hash with different text inputs
+SELECT lookup3be('test string');
+SELECT lookup3be('another test');
+
+-- Test text input with custom initval
+SELECT lookup3be('hello world', 42);
+SELECT lookup3be('hello world', 123);
+
+-- Test bytea input
+SELECT lookup3be('hello world'::bytea);
+
+-- Test bytea input with custom initval
+SELECT lookup3be('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT lookup3be(12345);
+SELECT lookup3be(-12345);
+
+-- Test integer input with custom initval
+SELECT lookup3be(12345, 42);
+SELECT lookup3be(-12345, 123);
+
+-- Test consistency (same input should give same hash)
+SELECT lookup3be('consistent test') = lookup3be('consistent test');
+
+-- Test initval effect (same input, different initvals should give different hashes)
+SELECT lookup3be('initval test', 1) != lookup3be('initval test', 2);
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'lookup3be'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Add lookup3be hash function to hashlib extension with support for text, bytea, and integer inputs, including custom seed functionality; update README and tests