### PR TITLE
feat: add SipHash-2-4 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pghashlib
 
-pghashlib is a PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, lookup2, lookup3be, and lookup3le algorithms.
+pghashlib is a PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, SipHash-2-4, lookup2, lookup3be, and lookup3le algorithms.
 
 ## Table of Contents
 
@@ -18,6 +18,7 @@ pghashlib is a PostgreSQL extension providing high-performance hash functions fo
    - [crc32](#crc32)
    - [cityhash64](#cityhash64)
    - [cityhash128](#cityhash128)
+   - [siphash24](#siphash24)
    - [lookup2](#lookup2)
    - [lookup3be](#lookup3be)
    - [lookup3le](#lookup3le)
@@ -121,6 +122,7 @@ CREATE EXTENSION hashlib;
 - **CRC32**: Cyclic redundancy check algorithm for error detection
 - **CityHash64**: High-performance 64-bit hash function from Google
 - **CityHash128**: High-performance 128-bit hash function from Google
+- **SipHash-2-4**: Cryptographic hash function designed for hash table protection against hash flooding attacks
 - **lookup2**: Bob Jenkins' lookup2 hash function - fast and well-distributed
 - **lookup3be**: Bob Jenkins' lookup3 hash function with big-endian byte order - improved version of lookup2
 - **lookup3le**: Bob Jenkins' lookup3 hash function with little-endian byte order - optimized for Intel/AMD systems
@@ -137,6 +139,7 @@ CREATE EXTENSION hashlib;
 | `crc32` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit CRC32 - cyclic redundancy check hash |
 | `cityhash64` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit CityHash - high-performance hash by Google |
 | `cityhash128` | `text`, `bytea`, `integer` | Yes | `bigint[]` | 128-bit CityHash - returns array of two 64-bit values |
+| `siphash24` | `text`, `bytea`, `integer` | Yes (2 seeds) | `bigint` | 64-bit SipHash-2-4 - cryptographic hash function |
 | `lookup2` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup2 - Bob Jenkins' hash function |
 | `lookup3be` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3be - Bob Jenkins' lookup3 with big-endian order |
 | `lookup3le` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3le - Bob Jenkins' lookup3 with little-endian order |
@@ -330,6 +333,56 @@ SELECT cityhash128(12345, 42, 84);
 SELECT 
     (cityhash128('hello world'))[1] AS low_64_bits,
     (cityhash128('hello world'))[2] AS high_64_bits;
+```
+
+</details>
+
+### siphash24
+
+SipHash-2-4 is a cryptographic hash function designed to provide strong protection against hash flooding attacks while maintaining good performance. It uses a 128-bit key for secure hashing.
+
+**Signatures:**
+- `siphash24(text)` → `bigint`
+- `siphash24(text, integer, integer)` → `bigint`
+- `siphash24(bytea)` → `bigint`
+- `siphash24(bytea, integer, integer)` → `bigint`
+- `siphash24(integer)` → `bigint`
+- `siphash24(integer, integer, integer)` → `bigint`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): First 32-bit seed value for 128-bit key
+- Third parameter (optional): Second 32-bit seed value for 128-bit key
+
+**Note:** SipHash-2-4 requires a 128-bit key for security. When using custom seeds, provide both 32-bit values. If no seeds are provided, a default key is used.
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default key
+SELECT siphash24('hello world');
+-- Result: Secure hash with default key
+
+-- Hash text with custom 128-bit key (two 32-bit seeds)
+SELECT siphash24('hello world', 42, 84);
+-- Result: Secure hash with custom key
+
+-- Hash bytea data
+SELECT siphash24('hello world'::bytea);
+-- Result: Secure hash of bytea data
+
+-- Hash bytea with custom key
+SELECT siphash24('hello world'::bytea, 42, 84);
+-- Result: Secure hash with custom key
+
+-- Hash integer values
+SELECT siphash24(12345);
+-- Result: Secure hash of integer
+
+-- Hash integer with custom key
+SELECT siphash24(12345, 42, 84);
+-- Result: Secure hash with custom key
 ```
 
 </details>
@@ -577,6 +630,7 @@ This project is licensed under the PostgreSQL License - see the [LICENSE](LICENS
 
 - MurmurHash3 algorithm by Austin Appleby
 - CityHash algorithm by Google Inc.
+- SipHash-2-4 algorithm by Jean-Philippe Aumasson and Daniel J. Bernstein
 - lookup2 and lookup3be algorithms by Bob Jenkins
 - PostgreSQL Extension Building Infrastructure (PGXS)
 - PostgreSQL Community for guidance and support

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -252,3 +252,39 @@ CREATE OR REPLACE FUNCTION lookup3be(integer, integer)
 RETURNS integer
 AS 'MODULE_PATHNAME', 'lookup3be_int_seed'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- SipHash24 function for text (default key)
+CREATE OR REPLACE FUNCTION siphash24(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'siphash24_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SipHash24 function for text with custom seeds (two 32-bit values for 128-bit key)
+CREATE OR REPLACE FUNCTION siphash24(text, integer, integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'siphash24_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SipHash24 function for bytea (default key)
+CREATE OR REPLACE FUNCTION siphash24(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'siphash24_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SipHash24 function for bytea with custom seeds (two 32-bit values for 128-bit key)
+CREATE OR REPLACE FUNCTION siphash24(bytea, integer, integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'siphash24_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SipHash24 function for integer (default key)
+CREATE OR REPLACE FUNCTION siphash24(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'siphash24_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SipHash24 function for integer with custom seeds (two 32-bit values for 128-bit key)
+CREATE OR REPLACE FUNCTION siphash24(integer, integer, integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'siphash24_int_seed'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/siphash24.c
+++ b/src/siphash24.c
@@ -1,0 +1,206 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+
+/* SipHash-2-4 constants */
+static const uint64_t SIP_K0_DEFAULT = 0x0706050403020100ULL;
+static const uint64_t SIP_K1_DEFAULT = 0x0f0e0d0c0b0a0908ULL;
+
+/* SipHash utility functions */
+static uint64_t
+U8TO64_LE(const unsigned char *p)
+{
+    return ((uint64_t)p[0]) |
+           ((uint64_t)p[1] << 8) |
+           ((uint64_t)p[2] << 16) |
+           ((uint64_t)p[3] << 24) |
+           ((uint64_t)p[4] << 32) |
+           ((uint64_t)p[5] << 40) |
+           ((uint64_t)p[6] << 48) |
+           ((uint64_t)p[7] << 56);
+}
+
+static uint64_t
+ROTL(uint64_t x, int b)
+{
+    return (x << b) | (x >> (64 - b));
+}
+
+static void
+SIPROUND(uint64_t *v0, uint64_t *v1, uint64_t *v2, uint64_t *v3)
+{
+    *v0 += *v1;
+    *v1 = ROTL(*v1, 13);
+    *v1 ^= *v0;
+    *v0 = ROTL(*v0, 32);
+    *v2 += *v3;
+    *v3 = ROTL(*v3, 16);
+    *v3 ^= *v2;
+    *v0 += *v3;
+    *v3 = ROTL(*v3, 21);
+    *v3 ^= *v0;
+    *v2 += *v1;
+    *v1 = ROTL(*v1, 17);
+    *v1 ^= *v2;
+    *v2 = ROTL(*v2, 32);
+}
+
+/* SipHash-2-4 main implementation */
+static uint64_t
+siphash24(const unsigned char *in, size_t inlen, uint64_t k0, uint64_t k1)
+{
+    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
+    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
+    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
+    uint64_t v3 = 0x7465646279746573ULL ^ k1;
+    uint64_t b;
+    size_t left = inlen & 7;
+    const unsigned char *end = in + inlen - left;
+    
+    b = ((uint64_t)inlen) << 56;
+    
+    /* Process 8-byte blocks */
+    for (; in != end; in += 8) {
+        uint64_t m = U8TO64_LE(in);
+        v3 ^= m;
+        
+        /* SipRound x 2 (c=2) */
+        SIPROUND(&v0, &v1, &v2, &v3);
+        SIPROUND(&v0, &v1, &v2, &v3);
+        
+        v0 ^= m;
+    }
+    
+    /* Process remaining bytes */
+    switch (left) {
+        case 7: b |= ((uint64_t)in[6]) << 48; /* fallthrough */
+        case 6: b |= ((uint64_t)in[5]) << 40; /* fallthrough */
+        case 5: b |= ((uint64_t)in[4]) << 32; /* fallthrough */
+        case 4: b |= ((uint64_t)in[3]) << 24; /* fallthrough */
+        case 3: b |= ((uint64_t)in[2]) << 16; /* fallthrough */
+        case 2: b |= ((uint64_t)in[1]) << 8;  /* fallthrough */
+        case 1: b |= ((uint64_t)in[0]);       /* fallthrough */
+        case 0: break;
+    }
+    
+    v3 ^= b;
+    
+    /* SipRound x 2 (c=2) */
+    SIPROUND(&v0, &v1, &v2, &v3);
+    SIPROUND(&v0, &v1, &v2, &v3);
+    
+    v0 ^= b;
+    
+    /* Finalization */
+    v2 ^= 0xff;
+    
+    /* SipRound x 4 (d=4) */
+    SIPROUND(&v0, &v1, &v2, &v3);
+    SIPROUND(&v0, &v1, &v2, &v3);
+    SIPROUND(&v0, &v1, &v2, &v3);
+    SIPROUND(&v0, &v1, &v2, &v3);
+    
+    return v0 ^ v1 ^ v2 ^ v3;
+}
+
+/* Helper function to convert two 32-bit integers to a 128-bit key */
+static void
+derive_key_from_seeds(uint32_t seed1, uint32_t seed2, uint64_t *k0, uint64_t *k1)
+{
+    *k0 = SIP_K0_DEFAULT ^ ((uint64_t)seed1 | ((uint64_t)seed2 << 32));
+    *k1 = SIP_K1_DEFAULT ^ ((uint64_t)seed2 | ((uint64_t)seed1 << 32));
+}
+
+/* SipHash24 for text input with default key */
+PG_FUNCTION_INFO_V1(siphash24_text);
+
+Datum
+siphash24_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = siphash24((const unsigned char *)data, len, SIP_K0_DEFAULT, SIP_K1_DEFAULT);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SipHash24 for text input with custom seeds */
+PG_FUNCTION_INFO_V1(siphash24_text_seed);
+
+Datum
+siphash24_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int32_t seed1 = PG_GETARG_INT32(1);
+    int32_t seed2 = PG_GETARG_INT32(2);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t k0, k1;
+    uint64_t hash;
+    
+    derive_key_from_seeds(seed1, seed2, &k0, &k1);
+    hash = siphash24((const unsigned char *)data, len, k0, k1);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SipHash24 for bytea input with default key */
+PG_FUNCTION_INFO_V1(siphash24_bytea);
+
+Datum
+siphash24_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = siphash24((const unsigned char *)data, len, SIP_K0_DEFAULT, SIP_K1_DEFAULT);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SipHash24 for bytea input with custom seeds */
+PG_FUNCTION_INFO_V1(siphash24_bytea_seed);
+
+Datum
+siphash24_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int32_t seed1 = PG_GETARG_INT32(1);
+    int32_t seed2 = PG_GETARG_INT32(2);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t k0, k1;
+    uint64_t hash;
+    
+    derive_key_from_seeds(seed1, seed2, &k0, &k1);
+    hash = siphash24((const unsigned char *)data, len, k0, k1);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SipHash24 for integer input with default key */
+PG_FUNCTION_INFO_V1(siphash24_int);
+
+Datum
+siphash24_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash = siphash24((const unsigned char *)&input, sizeof(int32_t), SIP_K0_DEFAULT, SIP_K1_DEFAULT);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SipHash24 for integer input with custom seeds */
+PG_FUNCTION_INFO_V1(siphash24_int_seed);
+
+Datum
+siphash24_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int32_t seed1 = PG_GETARG_INT32(1);
+    int32_t seed2 = PG_GETARG_INT32(2);
+    uint64_t k0, k1;
+    uint64_t hash;
+    
+    derive_key_from_seeds(seed1, seed2, &k0, &k1);
+    hash = siphash24((const unsigned char *)&input, sizeof(int32_t), k0, k1);
+    PG_RETURN_INT64((int64_t)hash);
+}

--- a/tests/expected/siphash24.out
+++ b/tests/expected/siphash24.out
@@ -1,0 +1,137 @@
+-- Test basic hash functionality with text
+SELECT siphash24('hello world');
+      siphash24       
+----------------------
+ -1346196092327471614
+(1 row)
+
+-- Test hash with different text inputs
+SELECT siphash24('test string');
+      siphash24      
+---------------------
+ 6538242980682147663
+(1 row)
+
+SELECT siphash24('another test');
+      siphash24      
+---------------------
+ 6332604165248306578
+(1 row)
+
+-- Test text input with custom seeds (two 32-bit values for 128-bit key)
+SELECT siphash24('hello world', 42, 84);
+      siphash24       
+----------------------
+ -3446223121447519457
+(1 row)
+
+SELECT siphash24('hello world', 123, 456);
+      siphash24       
+----------------------
+ -3511124341161720251
+(1 row)
+
+-- Test bytea input
+SELECT siphash24('hello world'::bytea);
+      siphash24       
+----------------------
+ -1346196092327471614
+(1 row)
+
+-- Test bytea input with custom seeds
+SELECT siphash24('hello world'::bytea, 42, 84);
+      siphash24       
+----------------------
+ -3446223121447519457
+(1 row)
+
+-- Test integer input
+SELECT siphash24(12345);
+      siphash24      
+---------------------
+ 4454067874901363441
+(1 row)
+
+SELECT siphash24(-12345);
+      siphash24       
+----------------------
+ -3806540918107243649
+(1 row)
+
+-- Test integer input with custom seeds
+SELECT siphash24(12345, 42, 84);
+      siphash24      
+---------------------
+ 6027795243152456333
+(1 row)
+
+SELECT siphash24(-12345, 123, 456);
+      siphash24      
+---------------------
+ 4629736804133087624
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT siphash24('consistent test') = siphash24('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT siphash24('seed test', 1, 2) != siphash24('seed test', 3, 4);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT siphash24('');
+      siphash24      
+---------------------
+ 8246050544436514353
+(1 row)
+
+-- Test single character
+SELECT siphash24('a');
+      siphash24      
+---------------------
+ 3144613055062689994
+(1 row)
+
+-- Test long string
+SELECT siphash24('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+     siphash24     
+-------------------
+ 64951999282399002
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'siphash24'
+ORDER BY proname, proargtypes;
+  proname  | provolatile | proisstrict 
+-----------+-------------+-------------
+ siphash24 | i           | t
+ siphash24 | i           | t
+ siphash24 | i           | t
+ siphash24 | i           | t
+ siphash24 | i           | t
+ siphash24 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/sql/siphash24.sql
+++ b/tests/sql/siphash24.sql
@@ -1,0 +1,55 @@
+-- Test basic hash functionality with text
+SELECT siphash24('hello world');
+
+-- Test hash with different text inputs
+SELECT siphash24('test string');
+SELECT siphash24('another test');
+
+-- Test text input with custom seeds (two 32-bit values for 128-bit key)
+SELECT siphash24('hello world', 42, 84);
+SELECT siphash24('hello world', 123, 456);
+
+-- Test bytea input
+SELECT siphash24('hello world'::bytea);
+
+-- Test bytea input with custom seeds
+SELECT siphash24('hello world'::bytea, 42, 84);
+
+-- Test integer input
+SELECT siphash24(12345);
+SELECT siphash24(-12345);
+
+-- Test integer input with custom seeds
+SELECT siphash24(12345, 42, 84);
+SELECT siphash24(-12345, 123, 456);
+
+-- Test consistency (same input should give same hash)
+SELECT siphash24('consistent test') = siphash24('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT siphash24('seed test', 1, 2) != siphash24('seed test', 3, 4);
+
+-- Test empty string
+SELECT siphash24('');
+
+-- Test single character
+SELECT siphash24('a');
+
+-- Test long string
+SELECT siphash24('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'siphash24'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Add SipHash-2-4 hash function to hashlib extension with support for text, bytea, and integer inputs; update README to include new algorithm details and examples