### PR TITLE
feat: add SpookyHash64 and SpookyHash128 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o src/spookyhash.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -288,3 +288,75 @@ CREATE OR REPLACE FUNCTION siphash24(integer, integer, integer)
 RETURNS bigint
 AS 'MODULE_PATHNAME', 'siphash24_int_seed'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash64 function for text (default seed)
+CREATE OR REPLACE FUNCTION spookyhash64(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'spookyhash64_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash64 function for text with custom seed
+CREATE OR REPLACE FUNCTION spookyhash64(text, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'spookyhash64_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash64 function for bytea (default seed)
+CREATE OR REPLACE FUNCTION spookyhash64(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'spookyhash64_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash64 function for bytea with custom seed
+CREATE OR REPLACE FUNCTION spookyhash64(bytea, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'spookyhash64_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash64 function for integer (default seed)
+CREATE OR REPLACE FUNCTION spookyhash64(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'spookyhash64_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash64 function for integer with custom seed
+CREATE OR REPLACE FUNCTION spookyhash64(integer, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'spookyhash64_int_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash128 function for text (default seed) - returns array of two bigints
+CREATE OR REPLACE FUNCTION spookyhash128(text)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'spookyhash128_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash128 function for text with custom seeds - returns array of two bigints
+CREATE OR REPLACE FUNCTION spookyhash128(text, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'spookyhash128_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash128 function for bytea (default seed) - returns array of two bigints
+CREATE OR REPLACE FUNCTION spookyhash128(bytea)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'spookyhash128_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash128 function for bytea with custom seeds - returns array of two bigints
+CREATE OR REPLACE FUNCTION spookyhash128(bytea, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'spookyhash128_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash128 function for integer (default seed) - returns array of two bigints
+CREATE OR REPLACE FUNCTION spookyhash128(integer)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'spookyhash128_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- SpookyHash128 function for integer with custom seeds - returns array of two bigints
+CREATE OR REPLACE FUNCTION spookyhash128(integer, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'spookyhash128_int_seed'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/spookyhash.c
+++ b/src/spookyhash.c
@@ -1,0 +1,462 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+#include "utils/array.h"
+#include "catalog/pg_type.h"
+
+/* SpookyHash constants */
+static const uint64_t sc_const = 0xdeadbeefdeadbeefULL;
+
+/* Allow unaligned reads - define based on platform */
+#ifndef ALLOW_UNALIGNED_READS
+#define ALLOW_UNALIGNED_READS 1
+#endif
+
+/* SpookyHash utility functions - removed unused ones */
+
+static void
+Short(const void *message, size_t length, uint64_t *hash1, uint64_t *hash2)
+{
+    uint64_t buf[2 * 12];
+    union {
+        const uint8_t *p8;
+        uint32_t *p32;
+        uint64_t *p64;
+        size_t i;
+    } u;
+    size_t remainder;
+    uint64_t a, b, c, d;
+    u.p8 = (const uint8_t *)message;
+
+    if (!ALLOW_UNALIGNED_READS && (u.i & 0x7)) {
+        memcpy(buf, message, length);
+        u.p64 = buf;
+    }
+
+    remainder = length % 32;
+    a = *hash1;
+    b = *hash2;
+    c = sc_const;
+    d = sc_const;
+
+    if (length > 15) {
+        const uint64_t *end = u.p64 + (length / 32) * 4;
+
+        /* handle all complete sets of 32 bytes */
+        for (; u.p64 < end; u.p64 += 4) {
+            c += u.p64[0];
+            d += u.p64[1];
+            a ^= c; a = (a << 50) | (a >> 14); d ^= a;
+            b ^= d; b = (b << 52) | (b >> 12); c ^= b;
+            c ^= u.p64[2];
+            d ^= u.p64[3];
+            a ^= c; a = (a << 23) | (a >> 41); d ^= a;
+            b ^= d; b = (b << 5) | (b >> 59); c ^= b;
+        }
+
+        /* Handle the case of 16+ remaining bytes. */
+        if (remainder >= 16) {
+            c += u.p64[0];
+            d += u.p64[1];
+            a ^= c; a = (a << 50) | (a >> 14); d ^= a;
+            b ^= d; b = (b << 52) | (b >> 12); c ^= b;
+            u.p64 += 2;
+            remainder -= 16;
+        }
+    }
+
+    /* Handle the last 0..15 bytes, and its length */
+    d += ((uint64_t)length) << 56;
+    switch (remainder) {
+        case 15: d += ((uint64_t)u.p8[14]) << 48; /* fallthrough */
+        case 14: d += ((uint64_t)u.p8[13]) << 40; /* fallthrough */
+        case 13: d += ((uint64_t)u.p8[12]) << 32; /* fallthrough */
+        case 12: d += u.p32[2]; c += u.p64[0]; break;
+        case 11: d += ((uint64_t)u.p8[10]) << 16; /* fallthrough */
+        case 10: d += ((uint64_t)u.p8[9]) << 8; /* fallthrough */
+        case 9: d += (uint64_t)u.p8[8]; /* fallthrough */
+        case 8: c += u.p64[0]; break;
+        case 7: c += ((uint64_t)u.p8[6]) << 48; /* fallthrough */
+        case 6: c += ((uint64_t)u.p8[5]) << 40; /* fallthrough */
+        case 5: c += ((uint64_t)u.p8[4]) << 32; /* fallthrough */
+        case 4: c += u.p32[0]; break;
+        case 3: c += ((uint64_t)u.p8[2]) << 16; /* fallthrough */
+        case 2: c += ((uint64_t)u.p8[1]) << 8; /* fallthrough */
+        case 1: c += (uint64_t)u.p8[0]; break;
+        case 0: c += sc_const; d += sc_const;
+    }
+    a ^= d; a = (a << 44) | (a >> 20); c ^= a;
+    b ^= c; b = (b << 15) | (b >> 49); d ^= b;
+    a ^= d; a = (a << 34) | (a >> 30); c ^= a;
+    b ^= c; b = (b << 21) | (b >> 43); d ^= b;
+    *hash1 = a;
+    *hash2 = b;
+}
+
+static void
+End(uint64_t *data, uint64_t *h0, uint64_t *h1, uint64_t *h2, uint64_t *h3, uint64_t *h4, uint64_t *h5, uint64_t *h6, uint64_t *h7, uint64_t *h8, uint64_t *h9, uint64_t *h10, uint64_t *h11)
+{
+    *h0 += data[0]; *h1 += data[1]; *h2 += data[2]; *h3 += data[3];
+    *h4 += data[4]; *h5 += data[5]; *h6 += data[6]; *h7 += data[7];
+    *h8 += data[8]; *h9 += data[9]; *h10 += data[10]; *h11 += data[11];
+    *h11^=*h1; *h2^=*h11; *h1 = (*h1<<44)|(*h1>>20);
+    *h0^=*h2; *h3^=*h0; *h2 = (*h2<<15)|(*h2>>49);
+    *h1^=*h3; *h4^=*h1; *h3 = (*h3<<34)|(*h3>>30);
+    *h2^=*h4; *h5^=*h2; *h4 = (*h4<<21)|(*h4>>43);
+    *h3^=*h5; *h6^=*h3; *h5 = (*h5<<14)|(*h5>>50);
+    *h4^=*h6; *h7^=*h4; *h6 = (*h6<<13)|(*h6>>51);
+    *h5^=*h7; *h8^=*h5; *h7 = (*h7<<11)|(*h7>>53);
+    *h6^=*h8; *h9^=*h6; *h8 = (*h8<<25)|(*h8>>39);
+    *h7^=*h9; *h10^=*h7; *h9 = (*h9<<42)|(*h9>>22);
+    *h8^=*h10; *h11^=*h8; *h10 = (*h10<<9)|(*h10>>55);
+    *h9^=*h11; *h0^=*h9; *h11 = (*h11<<35)|(*h11>>29);
+    *h10^=*h0; *h1^=*h10; *h0 = (*h0<<39)|(*h0>>25);
+}
+
+static void
+EndPartial(uint64_t *h0, uint64_t *h1, uint64_t *h2, uint64_t *h3, uint64_t *h4, uint64_t *h5, uint64_t *h6, uint64_t *h7, uint64_t *h8, uint64_t *h9, uint64_t *h10, uint64_t *h11)
+{
+    *h11+=*h1; *h2^=*h11; *h1 = (*h1<<44)|(*h1>>20);
+    *h0+=*h2; *h3^=*h0; *h2 = (*h2<<15)|(*h2>>49);
+    *h1+=*h3; *h4^=*h1; *h3 = (*h3<<34)|(*h3>>30);
+    *h2+=*h4; *h5^=*h2; *h4 = (*h4<<21)|(*h4>>43);
+    *h3+=*h5; *h6^=*h3; *h5 = (*h5<<14)|(*h5>>50);
+    *h4+=*h6; *h7^=*h4; *h6 = (*h6<<13)|(*h6>>51);
+    *h5+=*h7; *h8^=*h5; *h7 = (*h7<<11)|(*h7>>53);
+    *h6+=*h8; *h9^=*h6; *h8 = (*h8<<25)|(*h8>>39);
+    *h7+=*h9; *h10^=*h7; *h9 = (*h9<<42)|(*h9>>22);
+    *h8+=*h10; *h11^=*h8; *h10 = (*h10<<9)|(*h10>>55);
+    *h9+=*h11; *h0^=*h9; *h11 = (*h11<<35)|(*h11>>29);
+    *h10+=*h0; *h1^=*h10; *h0 = (*h0<<39)|(*h0>>25);
+}
+
+/* SpookyHash main implementation */
+static void
+spookyhash_128(const void *message, size_t length, uint64_t *hash1, uint64_t *hash2)
+{
+    uint64_t h0, h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11;
+    uint64_t buf[12];
+    uint64_t *end;
+    union {
+        const uint8_t *p8;
+        uint64_t *p64;
+        size_t i;
+    } u;
+    size_t remainder;
+
+    if (length < 192) {
+        Short(message, length, hash1, hash2);
+        return;
+    }
+
+    h0 = h3 = h6 = h9 = *hash1;
+    h1 = h4 = h7 = h10 = *hash2;
+    h2 = h5 = h8 = h11 = sc_const;
+
+    u.p8 = (const uint8_t *)message;
+    end = u.p64 + (length / 96) * 12;
+
+    /* handle all complete sets of 96 bytes */
+    if (ALLOW_UNALIGNED_READS || ((u.i & 0x7) == 0)) {
+        while (u.p64 < end) {
+            h0 += u.p64[0]; h1 += u.p64[1]; h2 += u.p64[2]; h3 += u.p64[3];
+            h4 += u.p64[4]; h5 += u.p64[5]; h6 += u.p64[6]; h7 += u.p64[7];
+            h8 += u.p64[8]; h9 += u.p64[9]; h10+= u.p64[10]; h11+= u.p64[11];
+            EndPartial(&h0,&h1,&h2,&h3,&h4,&h5,&h6,&h7,&h8,&h9,&h10,&h11);
+            u.p64 += 12;
+        }
+    } else {
+        while (u.p64 < end) {
+            memcpy(buf, u.p64, 96);
+            h0 += buf[0]; h1 += buf[1]; h2 += buf[2]; h3 += buf[3];
+            h4 += buf[4]; h5 += buf[5]; h6 += buf[6]; h7 += buf[7];
+            h8 += buf[8]; h9 += buf[9]; h10+= buf[10]; h11+= buf[11];
+            EndPartial(&h0,&h1,&h2,&h3,&h4,&h5,&h6,&h7,&h8,&h9,&h10,&h11);
+            u.p64 += 12;
+        }
+    }
+
+    /* handle the last partial block of 96 bytes */
+    remainder = (length - ((const uint8_t *)end - (const uint8_t *)message));
+    memcpy(buf, end, remainder);
+    memset(((uint8_t *)buf) + remainder, 0, 96 - remainder);
+    ((uint8_t *)buf)[95] = (uint8_t)remainder;
+
+    h0 += buf[0]; h1 += buf[1]; h2 += buf[2]; h3 += buf[3];
+    h4 += buf[4]; h5 += buf[5]; h6 += buf[6]; h7 += buf[7];
+    h8 += buf[8]; h9 += buf[9]; h10+= buf[10]; h11+= buf[11];
+    End(buf, &h0,&h1,&h2,&h3,&h4,&h5,&h6,&h7,&h8,&h9,&h10,&h11);
+
+    *hash1 = h0;
+    *hash2 = h1;
+}
+
+static uint64_t
+spookyhash_64(const void *message, size_t length, uint64_t seed)
+{
+    uint64_t hash1 = seed;
+    uint64_t hash2 = seed;
+    spookyhash_128(message, length, &hash1, &hash2);
+    return hash1;
+}
+
+/* SpookyHash64 for text input with default seed */
+PG_FUNCTION_INFO_V1(spookyhash64_text);
+
+Datum
+spookyhash64_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = spookyhash_64(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SpookyHash64 for text input with custom seed */
+PG_FUNCTION_INFO_V1(spookyhash64_text_seed);
+
+Datum
+spookyhash64_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = spookyhash_64(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SpookyHash64 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(spookyhash64_bytea);
+
+Datum
+spookyhash64_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = spookyhash_64(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SpookyHash64 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(spookyhash64_bytea_seed);
+
+Datum
+spookyhash64_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = spookyhash_64(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SpookyHash64 for integer input with default seed */
+PG_FUNCTION_INFO_V1(spookyhash64_int);
+
+Datum
+spookyhash64_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash = spookyhash_64(&input, sizeof(int32_t), 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SpookyHash64 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(spookyhash64_int_seed);
+
+Datum
+spookyhash64_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    uint64_t hash = spookyhash_64(&input, sizeof(int32_t), (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* SpookyHash128 for text input with default seed */
+PG_FUNCTION_INFO_V1(spookyhash128_text);
+
+Datum
+spookyhash128_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash1 = 0, hash2 = 0;
+    
+    Datum elems[2];
+    ArrayType *result;
+    int dims[1];
+    int lbs[1];
+    
+    spookyhash_128(data, len, &hash1, &hash2);
+    
+    elems[0] = Int64GetDatum((int64_t)hash1);
+    elems[1] = Int64GetDatum((int64_t)hash2);
+    
+    dims[0] = 2;
+    lbs[0] = 1;
+    
+    result = construct_md_array(elems, NULL, 1, dims, lbs,
+                               INT8OID, 8, true, 'd');
+    
+    PG_RETURN_ARRAYTYPE_P(result);
+}
+
+/* SpookyHash128 for text input with custom seeds */
+PG_FUNCTION_INFO_V1(spookyhash128_text_seed);
+
+Datum
+spookyhash128_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed1 = PG_GETARG_INT64(1);
+    int64_t seed2 = PG_GETARG_INT64(2);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash1 = (uint64_t)seed1, hash2 = (uint64_t)seed2;
+    
+    Datum elems[2];
+    ArrayType *result;
+    int dims[1];
+    int lbs[1];
+    
+    spookyhash_128(data, len, &hash1, &hash2);
+    
+    elems[0] = Int64GetDatum((int64_t)hash1);
+    elems[1] = Int64GetDatum((int64_t)hash2);
+    
+    dims[0] = 2;
+    lbs[0] = 1;
+    
+    result = construct_md_array(elems, NULL, 1, dims, lbs,
+                               INT8OID, 8, true, 'd');
+    
+    PG_RETURN_ARRAYTYPE_P(result);
+}
+
+/* SpookyHash128 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(spookyhash128_bytea);
+
+Datum
+spookyhash128_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash1 = 0, hash2 = 0;
+    
+    Datum elems[2];
+    ArrayType *result;
+    int dims[1];
+    int lbs[1];
+    
+    spookyhash_128(data, len, &hash1, &hash2);
+    
+    elems[0] = Int64GetDatum((int64_t)hash1);
+    elems[1] = Int64GetDatum((int64_t)hash2);
+    
+    dims[0] = 2;
+    lbs[0] = 1;
+    
+    result = construct_md_array(elems, NULL, 1, dims, lbs,
+                               INT8OID, 8, true, 'd');
+    
+    PG_RETURN_ARRAYTYPE_P(result);
+}
+
+/* SpookyHash128 for bytea input with custom seeds */
+PG_FUNCTION_INFO_V1(spookyhash128_bytea_seed);
+
+Datum
+spookyhash128_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed1 = PG_GETARG_INT64(1);
+    int64_t seed2 = PG_GETARG_INT64(2);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash1 = (uint64_t)seed1, hash2 = (uint64_t)seed2;
+    
+    Datum elems[2];
+    ArrayType *result;
+    int dims[1];
+    int lbs[1];
+    
+    spookyhash_128(data, len, &hash1, &hash2);
+    
+    elems[0] = Int64GetDatum((int64_t)hash1);
+    elems[1] = Int64GetDatum((int64_t)hash2);
+    
+    dims[0] = 2;
+    lbs[0] = 1;
+    
+    result = construct_md_array(elems, NULL, 1, dims, lbs,
+                               INT8OID, 8, true, 'd');
+    
+    PG_RETURN_ARRAYTYPE_P(result);
+}
+
+/* SpookyHash128 for integer input with default seed */
+PG_FUNCTION_INFO_V1(spookyhash128_int);
+
+Datum
+spookyhash128_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash1 = 0, hash2 = 0;
+    
+    Datum elems[2];
+    ArrayType *result;
+    int dims[1];
+    int lbs[1];
+    
+    spookyhash_128(&input, sizeof(int32_t), &hash1, &hash2);
+    
+    elems[0] = Int64GetDatum((int64_t)hash1);
+    elems[1] = Int64GetDatum((int64_t)hash2);
+    
+    dims[0] = 2;
+    lbs[0] = 1;
+    
+    result = construct_md_array(elems, NULL, 1, dims, lbs,
+                               INT8OID, 8, true, 'd');
+    
+    PG_RETURN_ARRAYTYPE_P(result);
+}
+
+/* SpookyHash128 for integer input with custom seeds */
+PG_FUNCTION_INFO_V1(spookyhash128_int_seed);
+
+Datum
+spookyhash128_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed1 = PG_GETARG_INT64(1);
+    int64_t seed2 = PG_GETARG_INT64(2);
+    uint64_t hash1 = (uint64_t)seed1, hash2 = (uint64_t)seed2;
+    
+    Datum elems[2];
+    ArrayType *result;
+    int dims[1];
+    int lbs[1];
+    
+    spookyhash_128(&input, sizeof(int32_t), &hash1, &hash2);
+    
+    elems[0] = Int64GetDatum((int64_t)hash1);
+    elems[1] = Int64GetDatum((int64_t)hash2);
+    
+    dims[0] = 2;
+    lbs[0] = 1;
+    
+    result = construct_md_array(elems, NULL, 1, dims, lbs,
+                               INT8OID, 8, true, 'd');
+    
+    PG_RETURN_ARRAYTYPE_P(result);
+}

--- a/tests/expected/spookyhash128.out
+++ b/tests/expected/spookyhash128.out
@@ -1,0 +1,146 @@
+-- Test basic hash functionality with text
+SELECT spookyhash128('hello world');
+               spookyhash128                
+--------------------------------------------
+ {-6863622830028382147,6569195265601149425}
+(1 row)
+
+-- Test hash with different text inputs
+SELECT spookyhash128('test string');
+                spookyhash128                
+---------------------------------------------
+ {-6860313425034751925,-5431870698529247433}
+(1 row)
+
+SELECT spookyhash128('another test');
+               spookyhash128               
+-------------------------------------------
+ {8357941537669845134,2308465386522311744}
+(1 row)
+
+-- Test text input with custom seeds (two 64-bit values)
+SELECT spookyhash128('hello world', 42, 84);
+               spookyhash128                
+--------------------------------------------
+ {-6910910637926309827,6593969530320424101}
+(1 row)
+
+SELECT spookyhash128('hello world', 123, 456);
+               spookyhash128                
+--------------------------------------------
+ {-6687982431137734595,6541028835711707911}
+(1 row)
+
+-- Test bytea input
+SELECT spookyhash128('hello world'::bytea);
+               spookyhash128                
+--------------------------------------------
+ {-6863622830028382147,6569195265601149425}
+(1 row)
+
+-- Test bytea input with custom seeds
+SELECT spookyhash128('hello world'::bytea, 42, 84);
+               spookyhash128                
+--------------------------------------------
+ {-6910910637926309827,6593969530320424101}
+(1 row)
+
+-- Test integer input
+SELECT spookyhash128(12345);
+               spookyhash128                
+--------------------------------------------
+ {3497333811451464082,-6999415554508147432}
+(1 row)
+
+SELECT spookyhash128(-12345);
+               spookyhash128                
+--------------------------------------------
+ {-885794525883594350,-7117083176598842520}
+(1 row)
+
+-- Test integer input with custom seeds
+SELECT spookyhash128(12345, 42, 84);
+               spookyhash128                
+--------------------------------------------
+ {3468060434275076498,-7028693281414799284}
+(1 row)
+
+SELECT spookyhash128(-12345, 123, 456);
+                spookyhash128                
+---------------------------------------------
+ {-1142499659010815598,-7145218270410202722}
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT spookyhash128('consistent test') = spookyhash128('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT spookyhash128('seed test', 1, 2) != spookyhash128('seed test', 3, 4);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT spookyhash128('');
+               spookyhash128                
+--------------------------------------------
+ {2741580708648471845,-3672138309541498381}
+(1 row)
+
+-- Test single character
+SELECT spookyhash128('a');
+                spookyhash128                
+---------------------------------------------
+ {-8036384833395030318,-1961767162533734888}
+(1 row)
+
+-- Test long string
+SELECT spookyhash128('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+               spookyhash128               
+-------------------------------------------
+ {1374786646752110901,-205646723213402587}
+(1 row)
+
+-- Test accessing individual parts of the 128-bit hash
+SELECT 
+    (spookyhash128('hello world'))[1] AS low_64_bits,
+    (spookyhash128('hello world'))[2] AS high_64_bits;
+     low_64_bits      |    high_64_bits     
+----------------------+---------------------
+ -6863622830028382147 | 6569195265601149425
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'spookyhash128'
+ORDER BY proname, proargtypes;
+    proname    | provolatile | proisstrict 
+---------------+-------------+-------------
+ spookyhash128 | i           | t
+ spookyhash128 | i           | t
+ spookyhash128 | i           | t
+ spookyhash128 | i           | t
+ spookyhash128 | i           | t
+ spookyhash128 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/spookyhash64.out
+++ b/tests/expected/spookyhash64.out
@@ -1,0 +1,137 @@
+-- Test basic hash functionality with text
+SELECT spookyhash64('hello world');
+     spookyhash64     
+----------------------
+ -6863622830028382147
+(1 row)
+
+-- Test hash with different text inputs
+SELECT spookyhash64('test string');
+     spookyhash64     
+----------------------
+ -6860313425034751925
+(1 row)
+
+SELECT spookyhash64('another test');
+    spookyhash64     
+---------------------
+ 8357941537669845134
+(1 row)
+
+-- Test text input with custom seed
+SELECT spookyhash64('hello world', 42);
+     spookyhash64     
+----------------------
+ -6851237942863650755
+(1 row)
+
+SELECT spookyhash64('hello world', 123);
+     spookyhash64     
+----------------------
+ -6896836863857041347
+(1 row)
+
+-- Test bytea input
+SELECT spookyhash64('hello world'::bytea);
+     spookyhash64     
+----------------------
+ -6863622830028382147
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT spookyhash64('hello world'::bytea, 42);
+     spookyhash64     
+----------------------
+ -6851237942863650755
+(1 row)
+
+-- Test integer input
+SELECT spookyhash64(12345);
+    spookyhash64     
+---------------------
+ 3497333811451464082
+(1 row)
+
+SELECT spookyhash64(-12345);
+    spookyhash64     
+---------------------
+ -885794525883594350
+(1 row)
+
+-- Test integer input with custom seed
+SELECT spookyhash64(12345, 42);
+    spookyhash64     
+---------------------
+ 3520977729896679826
+(1 row)
+
+SELECT spookyhash64(-12345, 123);
+    spookyhash64     
+---------------------
+ -917882627595712110
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT spookyhash64('consistent test') = spookyhash64('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT spookyhash64('seed test', 1) != spookyhash64('seed test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT spookyhash64('');
+    spookyhash64     
+---------------------
+ 2741580708648471845
+(1 row)
+
+-- Test single character
+SELECT spookyhash64('a');
+     spookyhash64     
+----------------------
+ -8036384833395030318
+(1 row)
+
+-- Test long string
+SELECT spookyhash64('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+    spookyhash64     
+---------------------
+ 1374786646752110901
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'spookyhash64'
+ORDER BY proname, proargtypes;
+   proname    | provolatile | proisstrict 
+--------------+-------------+-------------
+ spookyhash64 | i           | t
+ spookyhash64 | i           | t
+ spookyhash64 | i           | t
+ spookyhash64 | i           | t
+ spookyhash64 | i           | t
+ spookyhash64 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/sql/spookyhash128.sql
+++ b/tests/sql/spookyhash128.sql
@@ -1,0 +1,60 @@
+-- Test basic hash functionality with text
+SELECT spookyhash128('hello world');
+
+-- Test hash with different text inputs
+SELECT spookyhash128('test string');
+SELECT spookyhash128('another test');
+
+-- Test text input with custom seeds (two 64-bit values)
+SELECT spookyhash128('hello world', 42, 84);
+SELECT spookyhash128('hello world', 123, 456);
+
+-- Test bytea input
+SELECT spookyhash128('hello world'::bytea);
+
+-- Test bytea input with custom seeds
+SELECT spookyhash128('hello world'::bytea, 42, 84);
+
+-- Test integer input
+SELECT spookyhash128(12345);
+SELECT spookyhash128(-12345);
+
+-- Test integer input with custom seeds
+SELECT spookyhash128(12345, 42, 84);
+SELECT spookyhash128(-12345, 123, 456);
+
+-- Test consistency (same input should give same hash)
+SELECT spookyhash128('consistent test') = spookyhash128('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT spookyhash128('seed test', 1, 2) != spookyhash128('seed test', 3, 4);
+
+-- Test empty string
+SELECT spookyhash128('');
+
+-- Test single character
+SELECT spookyhash128('a');
+
+-- Test long string
+SELECT spookyhash128('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test accessing individual parts of the 128-bit hash
+SELECT 
+    (spookyhash128('hello world'))[1] AS low_64_bits,
+    (spookyhash128('hello world'))[2] AS high_64_bits;
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'spookyhash128'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/spookyhash64.sql
+++ b/tests/sql/spookyhash64.sql
@@ -1,0 +1,55 @@
+-- Test basic hash functionality with text
+SELECT spookyhash64('hello world');
+
+-- Test hash with different text inputs
+SELECT spookyhash64('test string');
+SELECT spookyhash64('another test');
+
+-- Test text input with custom seed
+SELECT spookyhash64('hello world', 42);
+SELECT spookyhash64('hello world', 123);
+
+-- Test bytea input
+SELECT spookyhash64('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT spookyhash64('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT spookyhash64(12345);
+SELECT spookyhash64(-12345);
+
+-- Test integer input with custom seed
+SELECT spookyhash64(12345, 42);
+SELECT spookyhash64(-12345, 123);
+
+-- Test consistency (same input should give same hash)
+SELECT spookyhash64('consistent test') = spookyhash64('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT spookyhash64('seed test', 1) != spookyhash64('seed test', 2);
+
+-- Test empty string
+SELECT spookyhash64('');
+
+-- Test single character
+SELECT spookyhash64('a');
+
+-- Test long string
+SELECT spookyhash64('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'spookyhash64'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Add SpookyHash64 and SpookyHash128 functions to hashlib extension with support for text, bytea, and integer inputs; update README to include new algorithm details and usage examples