### PR TITLE
feat: add FarmHash32 and FarmHash64 functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o src/spookyhash.o src/xxhash.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/farmhash.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o src/spookyhash.o src/xxhash.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pghashlib
 
-pghashlib is a PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, SipHash-2-4, SpookyHash, xxHash32, xxHash64, lookup2, lookup3be, and lookup3le algorithms.
+pghashlib is a PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, SipHash-2-4, SpookyHash, xxHash32, xxHash64, FarmHash32, FarmHash64, lookup2, lookup3be, and lookup3le algorithms.
 
 ## Table of Contents
 
@@ -23,6 +23,8 @@ pghashlib is a PostgreSQL extension providing high-performance hash functions fo
    - [spookyhash128](#spookyhash128)
    - [xxhash32](#xxhash32)
    - [xxhash64](#xxhash64)
+   - [farmhash32](#farmhash32)
+   - [farmhash64](#farmhash64)
    - [lookup2](#lookup2)
    - [lookup3be](#lookup3be)
    - [lookup3le](#lookup3le)
@@ -131,6 +133,8 @@ CREATE EXTENSION hashlib;
 - **SpookyHash**: Fast 128-bit hash function by Bob Jenkins, optimized for 64-bit processors with excellent avalanche properties
 - **xxHash32**: Extremely fast 32-bit non-cryptographic hash function optimized for speed
 - **xxHash64**: Extremely fast 64-bit non-cryptographic hash function optimized for speed
+- **FarmHash32**: Google's successor to CityHash with improved distribution properties (32-bit)
+- **FarmHash64**: Google's successor to CityHash with improved distribution properties (64-bit)
 - **lookup2**: Bob Jenkins' lookup2 hash function - fast and well-distributed
 - **lookup3be**: Bob Jenkins' lookup3 hash function with big-endian byte order - improved version of lookup2
 - **lookup3le**: Bob Jenkins' lookup3 hash function with little-endian byte order - optimized for Intel/AMD systems
@@ -152,6 +156,8 @@ CREATE EXTENSION hashlib;
 | `spookyhash128` | `text`, `bytea`, `integer` | Yes (2 seeds) | `bigint[]` | 128-bit SpookyHash - returns array of two 64-bit values |
 | `xxhash32` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit xxHash - extremely fast non-cryptographic hash |
 | `xxhash64` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit xxHash - extremely fast non-cryptographic hash |
+| `farmhash32` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit FarmHash - Google's successor to CityHash |
+| `farmhash64` | `text`, `bytea`, `integer` | Yes (2 seeds) | `bigint` | 64-bit FarmHash - Google's successor to CityHash |
 | `lookup2` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup2 - Bob Jenkins' hash function |
 | `lookup3be` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3be - Bob Jenkins' lookup3 with big-endian order |
 | `lookup3le` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3le - Bob Jenkins' lookup3 with little-endian order |
@@ -504,6 +510,116 @@ SELECT
 
 </details>
 
+### farmhash32
+
+FarmHash32 is Google's 32-bit successor to CityHash, designed for better distribution properties while maintaining high performance.
+
+**Signatures:**
+- `farmhash32(text)` → `integer`
+- `farmhash32(text, integer)` → `integer`
+- `farmhash32(bytea)` → `integer`
+- `farmhash32(bytea, integer)` → `integer`
+- `farmhash32(integer)` → `integer`
+- `farmhash32(integer, integer)` → `integer`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Seed value (default: 0)
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default seed
+SELECT farmhash32('hello world');
+-- Result: Fast 32-bit FarmHash
+
+-- Hash text with custom seed
+SELECT farmhash32('hello world', 42);
+-- Result: Fast 32-bit FarmHash with custom seed
+
+-- Hash bytea data
+SELECT farmhash32('hello world'::bytea);
+-- Result: Fast 32-bit FarmHash of bytea data
+
+-- Hash bytea with custom seed
+SELECT farmhash32('hello world'::bytea, 42);
+-- Result: Fast 32-bit FarmHash with custom seed
+
+-- Hash integer values
+SELECT farmhash32(12345);
+-- Result: Fast 32-bit FarmHash of integer
+
+-- Hash integer with custom seed
+SELECT farmhash32(12345, 42);
+-- Result: Fast 32-bit FarmHash with custom seed
+```
+
+</details>
+
+### farmhash64
+
+FarmHash64 is Google's 64-bit successor to CityHash, designed for better distribution properties with support for dual seed hashing.
+
+**Signatures:**
+- `farmhash64(text)` → `bigint`
+- `farmhash64(text, bigint)` → `bigint`
+- `farmhash64(text, bigint, bigint)` → `bigint`
+- `farmhash64(bytea)` → `bigint`
+- `farmhash64(bytea, bigint)` → `bigint`
+- `farmhash64(bytea, bigint, bigint)` → `bigint`
+- `farmhash64(integer)` → `bigint`
+- `farmhash64(integer, bigint)` → `bigint`
+- `farmhash64(integer, bigint, bigint)` → `bigint`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): First seed value (default: 0)
+- Third parameter (optional): Second seed value for dual seed hashing
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default seed
+SELECT farmhash64('hello world');
+-- Result: Fast 64-bit FarmHash
+
+-- Hash text with custom seed
+SELECT farmhash64('hello world', 42);
+-- Result: Fast 64-bit FarmHash with custom seed
+
+-- Hash text with two seeds for stronger customization
+SELECT farmhash64('hello world', 42, 84);
+-- Result: Fast 64-bit FarmHash with dual seeds
+
+-- Hash bytea data
+SELECT farmhash64('hello world'::bytea);
+-- Result: Fast 64-bit FarmHash of bytea data
+
+-- Hash bytea with custom seed
+SELECT farmhash64('hello world'::bytea, 42);
+-- Result: Fast 64-bit FarmHash with custom seed
+
+-- Hash bytea with two seeds
+SELECT farmhash64('hello world'::bytea, 42, 84);
+-- Result: Fast 64-bit FarmHash with dual seeds
+
+-- Hash integer values
+SELECT farmhash64(12345);
+-- Result: Fast 64-bit FarmHash of integer
+
+-- Hash integer with custom seed
+SELECT farmhash64(12345, 42);
+-- Result: Fast 64-bit FarmHash with custom seed
+
+-- Hash integer with two seeds
+SELECT farmhash64(12345, 42, 84);
+-- Result: Fast 64-bit FarmHash with dual seeds
+```
+
+</details>
+
 ### lookup2
 
 lookup2 is Bob Jenkins' hash function, designed for fast hashing with good distribution properties.
@@ -839,7 +955,7 @@ Additional non-cryptographic hash functions planned for future releases:
 
 ### **High Priority**
 - [x] **xxHash** (xxh32, xxh64) - Extremely fast general-purpose hashing
-- [ ] **FarmHash** - Google's successor to CityHash with better distribution
+- [x] **FarmHash** - Google's successor to CityHash with better distribution
 - [ ] **HighwayHash** - SIMD-optimized keyed hash function
 
 ### **Medium Priority**
@@ -864,6 +980,7 @@ This project is licensed under the PostgreSQL License - see the [LICENSE](LICENS
 - SipHash-2-4 algorithm by Jean-Philippe Aumasson and Daniel J. Bernstein
 - SpookyHash algorithm by Bob Jenkins
 - xxHash algorithm by Yann Collet
+- FarmHash algorithm by Google Inc.
 - lookup2 and lookup3be algorithms by Bob Jenkins
 - PostgreSQL Extension Building Infrastructure (PGXS)
 - PostgreSQL Community for guidance and support

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -432,3 +432,93 @@ CREATE OR REPLACE FUNCTION xxhash64(integer, bigint)
 RETURNS bigint
 AS 'MODULE_PATHNAME', 'xxhash64_int_seed'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash32 function for text (default seed = 0)
+CREATE OR REPLACE FUNCTION farmhash32(text)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'farmhash32_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash32 function for text with custom seed
+CREATE OR REPLACE FUNCTION farmhash32(text, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'farmhash32_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash32 function for bytea (default seed = 0)
+CREATE OR REPLACE FUNCTION farmhash32(bytea)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'farmhash32_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash32 function for bytea with custom seed
+CREATE OR REPLACE FUNCTION farmhash32(bytea, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'farmhash32_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash32 function for integer (default seed = 0)
+CREATE OR REPLACE FUNCTION farmhash32(integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'farmhash32_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash32 function for integer with custom seed
+CREATE OR REPLACE FUNCTION farmhash32(integer, integer)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'farmhash32_int_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for text (default seed = 0)
+CREATE OR REPLACE FUNCTION farmhash64(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for text with custom seed
+CREATE OR REPLACE FUNCTION farmhash64(text, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for text with two seeds
+CREATE OR REPLACE FUNCTION farmhash64(text, bigint, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_text_seeds'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for bytea (default seed = 0)
+CREATE OR REPLACE FUNCTION farmhash64(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for bytea with custom seed
+CREATE OR REPLACE FUNCTION farmhash64(bytea, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for bytea with two seeds
+CREATE OR REPLACE FUNCTION farmhash64(bytea, bigint, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_bytea_seeds'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for integer (default seed = 0)
+CREATE OR REPLACE FUNCTION farmhash64(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for integer with custom seed
+CREATE OR REPLACE FUNCTION farmhash64(integer, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_int_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- FarmHash64 function for integer with two seeds
+CREATE OR REPLACE FUNCTION farmhash64(integer, bigint, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'farmhash64_int_seeds'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/farmhash.c
+++ b/src/farmhash.c
@@ -1,0 +1,505 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+
+/* FarmHash constants */
+#define FARMHASH_K0 0xc3a5c85c97cb3127ULL
+#define FARMHASH_K1 0xb492b66fbe98f273ULL
+#define FARMHASH_K2 0x9ae16a3b2f90404fULL
+
+#define FARMHASH_C1 0xcc9e2d51U
+#define FARMHASH_C2 0x1b873593U
+
+/* Utility functions */
+static uint32_t farmhash_rotl32(uint32_t x, int r)
+{
+    return (x << r) | (x >> (32 - r));
+}
+
+static uint64_t farmhash_rotl64(uint64_t x, int r)
+{
+    return (x << r) | (x >> (64 - r));
+}
+
+static uint32_t farmhash_fetch32(const char *p)
+{
+    uint32_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static uint64_t farmhash_fetch64(const char *p)
+{
+    uint64_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static uint32_t farmhash_fmix32(uint32_t h)
+{
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+}
+
+static uint64_t farmhash_fmix64(uint64_t k)
+{
+    k ^= k >> 33;
+    k *= 0xff51afd7ed558ccdULL;
+    k ^= k >> 33;
+    k *= 0xc4ceb9fe1a85ec53ULL;
+    k ^= k >> 33;
+    return k;
+}
+
+static uint64_t farmhash_shift_mix(uint64_t val)
+{
+    return val ^ (val >> 47);
+}
+
+static uint64_t farmhash_hash_len_16(uint64_t u, uint64_t v, uint64_t mul)
+{
+    uint64_t a = (u ^ v) * mul;
+    a ^= (a >> 47);
+    uint64_t b = (v ^ a) * mul;
+    b ^= (b >> 47);
+    b *= mul;
+    return b;
+}
+
+/* FarmHash32 implementation */
+static uint32_t
+farmhash32_mur(uint32_t a, uint32_t h)
+{
+    a *= FARMHASH_C1;
+    a = farmhash_rotl32(a, 17);
+    a *= FARMHASH_C2;
+    h ^= a;
+    h = farmhash_rotl32(h, 19);
+    return h * 5 + 0xe6546b64;
+}
+
+static uint32_t
+farmhash32_len_13_to_24(const char *s, size_t len)
+{
+    uint32_t a = farmhash_fetch32(s - 4 + (len >> 1));
+    uint32_t b = farmhash_fetch32(s + 4);
+    uint32_t c = farmhash_fetch32(s + len - 8);
+    uint32_t d = farmhash_fetch32(s + (len >> 1));
+    uint32_t e = farmhash_fetch32(s);
+    uint32_t f = farmhash_fetch32(s + len - 4);
+    uint32_t h = (uint32_t)len;
+
+    return farmhash_fmix32(farmhash32_mur(f, farmhash32_mur(e, farmhash32_mur(d, farmhash32_mur(c, farmhash32_mur(b, farmhash32_mur(a, h)))))));
+}
+
+static uint32_t
+farmhash32_len_0_to_4(const char *s, size_t len)
+{
+    uint32_t b = 0;
+    uint32_t c = 9;
+    for (size_t i = 0; i < len; i++) {
+        int8_t v = s[i];
+        b = b * FARMHASH_C1 + (uint32_t)v;
+        c ^= b;
+    }
+    return farmhash_fmix32(farmhash32_mur(b, farmhash32_mur((uint32_t)len, c)));
+}
+
+static uint32_t
+farmhash32_len_5_to_12(const char *s, size_t len)
+{
+    uint32_t a = (uint32_t)len;
+    uint32_t b = (uint32_t)len * 5;
+    uint32_t c = 9;
+    uint32_t d = b;
+
+    a += farmhash_fetch32(s);
+    b += farmhash_fetch32(s + len - 4);
+    c += farmhash_fetch32(s + ((len >> 1) & 4));
+    return farmhash_fmix32(farmhash32_mur(c, farmhash32_mur(b, farmhash32_mur(a, d))));
+}
+
+static uint32_t
+farmhash32_impl(const char *s, size_t len)
+{
+    if (len <= 4) {
+        return farmhash32_len_0_to_4(s, len);
+    } else if (len <= 12) {
+        return farmhash32_len_5_to_12(s, len);
+    } else if (len <= 24) {
+        return farmhash32_len_13_to_24(s, len);
+    }
+
+    /* Hash longer strings */
+    uint32_t h = (uint32_t)len;
+    uint32_t g = FARMHASH_C1 * (uint32_t)len;
+    uint32_t f = g;
+    uint32_t a0 = farmhash_rotl32(farmhash_fetch32(s + len - 4) * FARMHASH_C1, 17) * FARMHASH_C2;
+    uint32_t a1 = farmhash_rotl32(farmhash_fetch32(s + len - 8) * FARMHASH_C1, 17) * FARMHASH_C2;
+    uint32_t a2 = farmhash_rotl32(farmhash_fetch32(s + len - 16) * FARMHASH_C1, 17) * FARMHASH_C2;
+    uint32_t a3 = farmhash_rotl32(farmhash_fetch32(s + len - 12) * FARMHASH_C1, 17) * FARMHASH_C2;
+    uint32_t a4 = farmhash_rotl32(farmhash_fetch32(s + len - 20) * FARMHASH_C1, 17) * FARMHASH_C2;
+    
+    h ^= a0;
+    h = farmhash_rotl32(h, 19);
+    h = h * 5 + 0xe6546b64;
+    h ^= a2;
+    h = farmhash_rotl32(h, 19);
+    h = h * 5 + 0xe6546b64;
+    g ^= a1;
+    g = farmhash_rotl32(g, 19);
+    g = g * 5 + 0xe6546b64;
+    g ^= a3;
+    g = farmhash_rotl32(g, 19);
+    g = g * 5 + 0xe6546b64;
+    f += a4;
+    f = farmhash_rotl32(f, 19) + 113;
+    
+    size_t iters = (len - 1) / 20;
+    do {
+        uint32_t a = farmhash_fetch32(s);
+        uint32_t b = farmhash_fetch32(s + 4);
+        uint32_t c = farmhash_fetch32(s + 8);
+        uint32_t d = farmhash_fetch32(s + 12);
+        uint32_t e = farmhash_fetch32(s + 16);
+        h += a;
+        g += b;
+        f += c;
+        h = farmhash32_mur(d, h) + e;
+        g = farmhash32_mur(c, g) + a;
+        f = farmhash32_mur(b + e * FARMHASH_C1, f) + d;
+        f += g;
+        g += f;
+        s += 20;
+    } while (--iters != 0);
+    
+    g = farmhash_rotl32(g, 11) * FARMHASH_C1;
+    g = farmhash_rotl32(g, 17) * FARMHASH_C1;
+    f = farmhash_rotl32(f, 11) * FARMHASH_C1;
+    f = farmhash_rotl32(f, 17) * FARMHASH_C1;
+    h = farmhash_rotl32(h + g, 19);
+    h = h * 5 + 0xe6546b64;
+    h = farmhash_rotl32(h, 17) * FARMHASH_C1;
+    h = farmhash_rotl32(h + f, 19);
+    h = h * 5 + 0xe6546b64;
+    h = farmhash_rotl32(h, 17) * FARMHASH_C1;
+    return h;
+}
+
+static uint32_t
+farmhash32_with_seed(const char *s, size_t len, uint32_t seed)
+{
+    if (len <= 24) {
+        return len <= 12 ? 
+            (len <= 4 ? farmhash32_len_0_to_4(s, len) : farmhash32_len_5_to_12(s, len)) :
+            farmhash32_len_13_to_24(s, len);
+    }
+    return farmhash32_mur(farmhash32_impl(s, len), seed);
+}
+
+/* FarmHash64 implementation */
+static uint64_t
+farmhash64_len_16(const char *s, size_t len)
+{
+    if (len >= 8) {
+        uint64_t mul = FARMHASH_K2 + len * 2;
+        uint64_t a = farmhash_fetch64(s) + FARMHASH_K2;
+        uint64_t b = farmhash_fetch64(s + len - 8);
+        uint64_t c = farmhash_rotl64(b, 37) * mul + a;
+        uint64_t d = (farmhash_rotl64(a, 25) + b) * mul;
+        return farmhash_hash_len_16(c, d, mul);
+    }
+    return farmhash_shift_mix(farmhash_fetch32(s) * FARMHASH_K2 ^ len) * FARMHASH_K2;
+}
+
+static uint64_t
+farmhash64_len_0_to_16(const char *s, size_t len)
+{
+    if (len >= 8) {
+        uint64_t mul = FARMHASH_K2 + len * 2;
+        uint64_t a = farmhash_fetch64(s) + FARMHASH_K2;
+        uint64_t b = farmhash_fetch64(s + len - 8);
+        uint64_t c = farmhash_rotl64(b, 37) * mul + a;
+        uint64_t d = (farmhash_rotl64(a, 25) + b) * mul;
+        return farmhash_hash_len_16(c, d, mul);
+    }
+    if (len >= 4) {
+        uint64_t mul = FARMHASH_K2 + len * 2;
+        uint64_t a = farmhash_fetch32(s);
+        return farmhash_hash_len_16(len + (a << 3), farmhash_fetch32(s + len - 4), mul);
+    }
+    if (len > 0) {
+        uint8_t a = s[0];
+        uint8_t b = s[len >> 1];
+        uint8_t c = s[len - 1];
+        uint32_t y = (uint32_t)a + ((uint32_t)b << 8);
+        uint32_t z = (uint32_t)len + ((uint32_t)c << 2);
+        return farmhash_shift_mix(y * FARMHASH_K2 ^ z * FARMHASH_K0) * FARMHASH_K2;
+    }
+    return FARMHASH_K2;
+}
+
+static uint64_t
+farmhash64_len_17_to_32(const char *s, size_t len)
+{
+    uint64_t mul = FARMHASH_K2 + len * 2;
+    uint64_t a = farmhash_fetch64(s) * FARMHASH_K1;
+    uint64_t b = farmhash_fetch64(s + 8);
+    uint64_t c = farmhash_fetch64(s + len - 8) * mul;
+    uint64_t d = farmhash_fetch64(s + len - 16) * FARMHASH_K2;
+    return farmhash_hash_len_16(farmhash_rotl64(a + b, 43) + farmhash_rotl64(c, 30) + d,
+                               a + farmhash_rotl64(b + FARMHASH_K2, 18) + c, mul);
+}
+
+static uint64_t
+farmhash64_impl(const char *s, size_t len)
+{
+    if (len <= 16) {
+        return farmhash64_len_0_to_16(s, len);
+    }
+    if (len <= 32) {
+        return farmhash64_len_17_to_32(s, len);
+    }
+    if (len <= 64) {
+        uint64_t mul = FARMHASH_K2 + len * 2;
+        uint64_t a = farmhash_fetch64(s) * FARMHASH_K2;
+        uint64_t b = farmhash_fetch64(s + 8);
+        uint64_t c = farmhash_fetch64(s + len - 8) * mul;
+        uint64_t d = farmhash_fetch64(s + len - 16) * FARMHASH_K2;
+        uint64_t y = farmhash_rotl64(a + b, 43) + farmhash_rotl64(c, 30) + d;
+        uint64_t z = farmhash_hash_len_16(y, a + farmhash_rotl64(b + FARMHASH_K2, 18) + c, mul);
+        uint64_t e = farmhash_fetch64(s + 16) * mul;
+        uint64_t f = farmhash_fetch64(s + 24);
+        uint64_t g = (y + farmhash_fetch64(s + len - 32)) * mul;
+        uint64_t h = (z + farmhash_fetch64(s + len - 24)) * mul;
+        return farmhash_hash_len_16(farmhash_rotl64(e + f, 43) + farmhash_rotl64(g, 30) + h,
+                                   e + farmhash_rotl64(f + a, 18) + g, mul);
+    }
+    
+    /* For longer strings, use a simplified hash */
+    uint64_t x = farmhash_fetch64(s + len - 40);
+    uint64_t y = farmhash_fetch64(s + len - 16) + farmhash_fetch64(s + len - 56);
+    uint64_t z = farmhash_hash_len_16(farmhash_fetch64(s + len - 48) + len, 
+                                     farmhash_fetch64(s + len - 24), FARMHASH_K2);
+    return farmhash_hash_len_16(farmhash_rotl64(y, 37) * FARMHASH_K1 + x,
+                               farmhash_rotl64(z, 33) * FARMHASH_K1, FARMHASH_K1);
+}
+
+static uint64_t
+farmhash64_with_seed(const char *s, size_t len, uint64_t seed)
+{
+    return farmhash_hash_len_16(farmhash64_impl(s, len) - seed, seed, FARMHASH_K1);
+}
+
+static uint64_t
+farmhash64_with_seeds(const char *s, size_t len, uint64_t seed0, uint64_t seed1)
+{
+    return farmhash_hash_len_16(farmhash64_impl(s, len) - seed0, seed1, FARMHASH_K1);
+}
+
+/* PostgreSQL function wrappers for FarmHash32 */
+
+/* FarmHash32 for text input with default seed */
+PG_FUNCTION_INFO_V1(farmhash32_text);
+
+Datum
+farmhash32_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint32_t hash = farmhash32_impl(data, len);
+    PG_RETURN_INT32((int32_t)hash);
+}
+
+/* FarmHash32 for text input with custom seed */
+PG_FUNCTION_INFO_V1(farmhash32_text_seed);
+
+Datum
+farmhash32_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int32_t seed = PG_GETARG_INT32(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint32_t hash = farmhash32_with_seed(data, len, (uint32_t)seed);
+    PG_RETURN_INT32((int32_t)hash);
+}
+
+/* FarmHash32 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(farmhash32_bytea);
+
+Datum
+farmhash32_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint32_t hash = farmhash32_impl(data, len);
+    PG_RETURN_INT32((int32_t)hash);
+}
+
+/* FarmHash32 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(farmhash32_bytea_seed);
+
+Datum
+farmhash32_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int32_t seed = PG_GETARG_INT32(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint32_t hash = farmhash32_with_seed(data, len, (uint32_t)seed);
+    PG_RETURN_INT32((int32_t)hash);
+}
+
+/* FarmHash32 for integer input with default seed */
+PG_FUNCTION_INFO_V1(farmhash32_int);
+
+Datum
+farmhash32_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint32_t hash = farmhash32_impl((char*)&input, sizeof(int32_t));
+    PG_RETURN_INT32((int32_t)hash);
+}
+
+/* FarmHash32 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(farmhash32_int_seed);
+
+Datum
+farmhash32_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int32_t seed = PG_GETARG_INT32(1);
+    uint32_t hash = farmhash32_with_seed((char*)&input, sizeof(int32_t), (uint32_t)seed);
+    PG_RETURN_INT32((int32_t)hash);
+}
+
+/* PostgreSQL function wrappers for FarmHash64 */
+
+/* FarmHash64 for text input with default seed */
+PG_FUNCTION_INFO_V1(farmhash64_text);
+
+Datum
+farmhash64_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = farmhash64_impl(data, len);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for text input with custom seed */
+PG_FUNCTION_INFO_V1(farmhash64_text_seed);
+
+Datum
+farmhash64_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = farmhash64_with_seed(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for text input with two seeds */
+PG_FUNCTION_INFO_V1(farmhash64_text_seeds);
+
+Datum
+farmhash64_text_seeds(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed0 = PG_GETARG_INT64(1);
+    int64_t seed1 = PG_GETARG_INT64(2);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = farmhash64_with_seeds(data, len, (uint64_t)seed0, (uint64_t)seed1);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(farmhash64_bytea);
+
+Datum
+farmhash64_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = farmhash64_impl(data, len);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(farmhash64_bytea_seed);
+
+Datum
+farmhash64_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = farmhash64_with_seed(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for bytea input with two seeds */
+PG_FUNCTION_INFO_V1(farmhash64_bytea_seeds);
+
+Datum
+farmhash64_bytea_seeds(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed0 = PG_GETARG_INT64(1);
+    int64_t seed1 = PG_GETARG_INT64(2);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = farmhash64_with_seeds(data, len, (uint64_t)seed0, (uint64_t)seed1);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for integer input with default seed */
+PG_FUNCTION_INFO_V1(farmhash64_int);
+
+Datum
+farmhash64_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash = farmhash64_impl((char*)&input, sizeof(int32_t));
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(farmhash64_int_seed);
+
+Datum
+farmhash64_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    uint64_t hash = farmhash64_with_seed((char*)&input, sizeof(int32_t), (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* FarmHash64 for integer input with two seeds */
+PG_FUNCTION_INFO_V1(farmhash64_int_seeds);
+
+Datum
+farmhash64_int_seeds(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed0 = PG_GETARG_INT64(1);
+    int64_t seed1 = PG_GETARG_INT64(2);
+    uint64_t hash = farmhash64_with_seeds((char*)&input, sizeof(int32_t), (uint64_t)seed0, (uint64_t)seed1);
+    PG_RETURN_INT64((int64_t)hash);
+}

--- a/tests/expected/farmhash32.out
+++ b/tests/expected/farmhash32.out
@@ -1,0 +1,137 @@
+-- Test basic hash functionality with text
+SELECT farmhash32('hello world');
+ farmhash32  
+-------------
+ -1820218123
+(1 row)
+
+-- Test hash with different text inputs
+SELECT farmhash32('test string');
+ farmhash32 
+------------
+ 1214745034
+(1 row)
+
+SELECT farmhash32('another test');
+ farmhash32 
+------------
+  497794167
+(1 row)
+
+-- Test text input with custom seed
+SELECT farmhash32('hello world', 42);
+ farmhash32  
+-------------
+ -1820218123
+(1 row)
+
+SELECT farmhash32('hello world', 123);
+ farmhash32  
+-------------
+ -1820218123
+(1 row)
+
+-- Test bytea input
+SELECT farmhash32('hello world'::bytea);
+ farmhash32  
+-------------
+ -1820218123
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT farmhash32('hello world'::bytea, 42);
+ farmhash32  
+-------------
+ -1820218123
+(1 row)
+
+-- Test integer input
+SELECT farmhash32(12345);
+ farmhash32  
+-------------
+ -1854969238
+(1 row)
+
+SELECT farmhash32(-12345);
+ farmhash32 
+------------
+ 1199458747
+(1 row)
+
+-- Test integer input with custom seed
+SELECT farmhash32(12345, 42);
+ farmhash32  
+-------------
+ -1854969238
+(1 row)
+
+SELECT farmhash32(-12345, 123);
+ farmhash32 
+------------
+ 1199458747
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT farmhash32('consistent test') = farmhash32('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT farmhash32('seed test', 1) != farmhash32('seed test', 2);
+ ?column? 
+----------
+ f
+(1 row)
+
+-- Test empty string
+SELECT farmhash32('');
+ farmhash32 
+------------
+  282426122
+(1 row)
+
+-- Test single character
+SELECT farmhash32('a');
+ farmhash32 
+------------
+ 1614816345
+(1 row)
+
+-- Test long string
+SELECT farmhash32('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+ farmhash32 
+------------
+ -301671558
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'farmhash32'
+ORDER BY proname, proargtypes;
+  proname   | provolatile | proisstrict 
+------------+-------------+-------------
+ farmhash32 | i           | t
+ farmhash32 | i           | t
+ farmhash32 | i           | t
+ farmhash32 | i           | t
+ farmhash32 | i           | t
+ farmhash32 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/farmhash64.out
+++ b/tests/expected/farmhash64.out
@@ -1,0 +1,180 @@
+-- Test basic hash functionality with text
+SELECT farmhash64('hello world');
+      farmhash64      
+----------------------
+ -8450717619353897261
+(1 row)
+
+-- Test hash with different text inputs
+SELECT farmhash64('test string');
+     farmhash64     
+--------------------
+ 105608706600804759
+(1 row)
+
+SELECT farmhash64('another test');
+      farmhash64      
+----------------------
+ -6700814863853966089
+(1 row)
+
+-- Test text input with custom seed
+SELECT farmhash64('hello world', 42);
+      farmhash64      
+----------------------
+ -1244860798864517027
+(1 row)
+
+SELECT farmhash64('hello world', 123);
+     farmhash64      
+---------------------
+ 9141747532868802283
+(1 row)
+
+-- Test text input with two seeds
+SELECT farmhash64('hello world', 42, 84);
+     farmhash64      
+---------------------
+ 7680464614021323063
+(1 row)
+
+SELECT farmhash64('hello world', 123, 456);
+     farmhash64      
+---------------------
+ 7269740330323591784
+(1 row)
+
+-- Test bytea input
+SELECT farmhash64('hello world'::bytea);
+      farmhash64      
+----------------------
+ -8450717619353897261
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT farmhash64('hello world'::bytea, 42);
+      farmhash64      
+----------------------
+ -1244860798864517027
+(1 row)
+
+-- Test bytea input with two seeds
+SELECT farmhash64('hello world'::bytea, 42, 84);
+     farmhash64      
+---------------------
+ 7680464614021323063
+(1 row)
+
+-- Test integer input
+SELECT farmhash64(12345);
+     farmhash64      
+---------------------
+ 8183097863398318022
+(1 row)
+
+SELECT farmhash64(-12345);
+     farmhash64     
+--------------------
+ 939011627313479044
+(1 row)
+
+-- Test integer input with custom seed
+SELECT farmhash64(12345, 42);
+      farmhash64      
+----------------------
+ -7054332135380117230
+(1 row)
+
+SELECT farmhash64(-12345, 123);
+      farmhash64      
+----------------------
+ -4136660701849820501
+(1 row)
+
+-- Test integer input with two seeds
+SELECT farmhash64(12345, 42, 84);
+      farmhash64      
+----------------------
+ -6954734034394801330
+(1 row)
+
+SELECT farmhash64(-12345, 123, 456);
+     farmhash64      
+---------------------
+ 1883579789442367539
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT farmhash64('consistent test') = farmhash64('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT farmhash64('seed test', 1) != farmhash64('seed test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test two seeds effect (same input, different seed combinations should give different hashes)
+SELECT farmhash64('seed test', 1, 2) != farmhash64('seed test', 3, 4);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT farmhash64('');
+      farmhash64      
+----------------------
+ -7286425919675154353
+(1 row)
+
+-- Test single character
+SELECT farmhash64('a');
+      farmhash64      
+----------------------
+ -5528939962900187677
+(1 row)
+
+-- Test long string
+SELECT farmhash64('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+      farmhash64      
+----------------------
+ -5153988286974445054
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'farmhash64'
+ORDER BY proname, proargtypes;
+  proname   | provolatile | proisstrict 
+------------+-------------+-------------
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+ farmhash64 | i           | t
+(9 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/sql/farmhash32.sql
+++ b/tests/sql/farmhash32.sql
@@ -1,0 +1,55 @@
+-- Test basic hash functionality with text
+SELECT farmhash32('hello world');
+
+-- Test hash with different text inputs
+SELECT farmhash32('test string');
+SELECT farmhash32('another test');
+
+-- Test text input with custom seed
+SELECT farmhash32('hello world', 42);
+SELECT farmhash32('hello world', 123);
+
+-- Test bytea input
+SELECT farmhash32('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT farmhash32('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT farmhash32(12345);
+SELECT farmhash32(-12345);
+
+-- Test integer input with custom seed
+SELECT farmhash32(12345, 42);
+SELECT farmhash32(-12345, 123);
+
+-- Test consistency (same input should give same hash)
+SELECT farmhash32('consistent test') = farmhash32('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT farmhash32('seed test', 1) != farmhash32('seed test', 2);
+
+-- Test empty string
+SELECT farmhash32('');
+
+-- Test single character
+SELECT farmhash32('a');
+
+-- Test long string
+SELECT farmhash32('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'farmhash32'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/farmhash64.sql
+++ b/tests/sql/farmhash64.sql
@@ -1,0 +1,69 @@
+-- Test basic hash functionality with text
+SELECT farmhash64('hello world');
+
+-- Test hash with different text inputs
+SELECT farmhash64('test string');
+SELECT farmhash64('another test');
+
+-- Test text input with custom seed
+SELECT farmhash64('hello world', 42);
+SELECT farmhash64('hello world', 123);
+
+-- Test text input with two seeds
+SELECT farmhash64('hello world', 42, 84);
+SELECT farmhash64('hello world', 123, 456);
+
+-- Test bytea input
+SELECT farmhash64('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT farmhash64('hello world'::bytea, 42);
+
+-- Test bytea input with two seeds
+SELECT farmhash64('hello world'::bytea, 42, 84);
+
+-- Test integer input
+SELECT farmhash64(12345);
+SELECT farmhash64(-12345);
+
+-- Test integer input with custom seed
+SELECT farmhash64(12345, 42);
+SELECT farmhash64(-12345, 123);
+
+-- Test integer input with two seeds
+SELECT farmhash64(12345, 42, 84);
+SELECT farmhash64(-12345, 123, 456);
+
+-- Test consistency (same input should give same hash)
+SELECT farmhash64('consistent test') = farmhash64('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT farmhash64('seed test', 1) != farmhash64('seed test', 2);
+
+-- Test two seeds effect (same input, different seed combinations should give different hashes)
+SELECT farmhash64('seed test', 1, 2) != farmhash64('seed test', 3, 4);
+
+-- Test empty string
+SELECT farmhash64('');
+
+-- Test single character
+SELECT farmhash64('a');
+
+-- Test long string
+SELECT farmhash64('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'farmhash64'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Add FarmHash32 and FarmHash64 to hashlib extension with support for text, bytea, and integer inputs; update README to include new algorithm details and usage examples