### PR TITLE
feat: add HighwayHash functions (64, 128, 256 bits)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/farmhash.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o src/spookyhash.o src/xxhash.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/farmhash.o src/highwayhash.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/murmur.o src/siphash24.o src/spookyhash.o src/xxhash.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -522,3 +522,111 @@ CREATE OR REPLACE FUNCTION farmhash64(integer, bigint, bigint)
 RETURNS bigint
 AS 'MODULE_PATHNAME', 'farmhash64_int_seeds'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash64 function for text (default key)
+CREATE OR REPLACE FUNCTION highwayhash64(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'highwayhash64_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash64 function for text with custom key (4 bigint values)
+CREATE OR REPLACE FUNCTION highwayhash64(text, bigint, bigint, bigint, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'highwayhash64_text_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash64 function for bytea (default key)
+CREATE OR REPLACE FUNCTION highwayhash64(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'highwayhash64_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash64 function for bytea with custom key (4 bigint values)
+CREATE OR REPLACE FUNCTION highwayhash64(bytea, bigint, bigint, bigint, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'highwayhash64_bytea_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash64 function for integer (default key)
+CREATE OR REPLACE FUNCTION highwayhash64(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'highwayhash64_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash64 function for integer with custom key (4 bigint values)
+CREATE OR REPLACE FUNCTION highwayhash64(integer, bigint, bigint, bigint, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'highwayhash64_int_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash128 function for text (default key) - returns array of two bigints
+CREATE OR REPLACE FUNCTION highwayhash128(text)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash128_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash128 function for text with custom key (4 bigint values) - returns array of two bigints
+CREATE OR REPLACE FUNCTION highwayhash128(text, bigint, bigint, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash128_text_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash128 function for bytea (default key) - returns array of two bigints
+CREATE OR REPLACE FUNCTION highwayhash128(bytea)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash128_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash128 function for bytea with custom key (4 bigint values) - returns array of two bigints
+CREATE OR REPLACE FUNCTION highwayhash128(bytea, bigint, bigint, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash128_bytea_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash128 function for integer (default key) - returns array of two bigints
+CREATE OR REPLACE FUNCTION highwayhash128(integer)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash128_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash128 function for integer with custom key (4 bigint values) - returns array of two bigints
+CREATE OR REPLACE FUNCTION highwayhash128(integer, bigint, bigint, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash128_int_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash256 function for text (default key) - returns array of four bigints
+CREATE OR REPLACE FUNCTION highwayhash256(text)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash256_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash256 function for text with custom key (4 bigint values) - returns array of four bigints
+CREATE OR REPLACE FUNCTION highwayhash256(text, bigint, bigint, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash256_text_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash256 function for bytea (default key) - returns array of four bigints
+CREATE OR REPLACE FUNCTION highwayhash256(bytea)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash256_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash256 function for bytea with custom key (4 bigint values) - returns array of four bigints
+CREATE OR REPLACE FUNCTION highwayhash256(bytea, bigint, bigint, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash256_bytea_key'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash256 function for integer (default key) - returns array of four bigints
+CREATE OR REPLACE FUNCTION highwayhash256(integer)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash256_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- HighwayHash256 function for integer with custom key (4 bigint values) - returns array of four bigints
+CREATE OR REPLACE FUNCTION highwayhash256(integer, bigint, bigint, bigint, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 'highwayhash256_int_key'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/highwayhash.c
+++ b/src/highwayhash.c
@@ -1,0 +1,671 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "utils/array.h"
+#include "catalog/pg_type.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+
+/* HighwayHash constants and state */
+#define HH_LANES 4
+#define HH_KEY_BYTES 32
+
+/* HighwayHash initialization constants */
+static const uint64_t HH_INIT0[HH_LANES] = { 0xdbe6d5d5fe4cce2fULL, 0xa4093822299f31d0ULL, 0x13198a2e03707344ULL, 0x243f6a8885a308d3ULL };
+static const uint64_t HH_INIT1[HH_LANES] = { 0x3bd39e10cb0ef593ULL, 0xc0acf169b5f18a8cULL, 0xbe5466cf34e90c6cULL, 0x452821e638d01377ULL };
+
+/* HighwayHash state structure */
+typedef struct {
+    uint64_t v0[HH_LANES];
+    uint64_t v1[HH_LANES];
+    uint64_t mul0[HH_LANES];
+    uint64_t mul1[HH_LANES];
+} hh_state;
+
+/* Utility functions */
+static uint64_t hh_rotl64(uint64_t x, int r)
+{
+    return (x << r) | (x >> (64 - r));
+}
+
+static uint64_t hh_fetch64(const char *p)
+{
+    uint64_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+
+/* ZipperMerge: Computes (a + b) % 2^64 and (a + b) >> 32 */
+static void hh_zipper_merge(uint64_t v1, uint64_t v0, uint64_t *result)
+{
+    result[0] = (v0 + v1) & 0xFFFFFFFFULL;
+    result[1] = (v0 + v1) >> 32;
+}
+
+/* HighwayHash Update */
+static void hh_update(const uint64_t lanes[HH_LANES], hh_state *state)
+{
+    int i;
+    for (i = 0; i < HH_LANES; ++i) {
+        state->v1[i] += state->mul0[i] + lanes[i];
+        state->mul0[i] ^= (state->v1[i] & 0xFFFFFFFFULL) * (state->v0[i] >> 32);
+        state->v0[i] += state->mul1[i];
+        state->mul1[i] ^= (state->v0[i] & 0xFFFFFFFFULL) * (state->v1[i] >> 32);
+    }
+
+    /* ZipperMerge and update v0/v1 */
+    {
+        uint64_t result0[2], result1[2];
+        hh_zipper_merge(state->v1[1], state->v1[0], result0);
+        hh_zipper_merge(state->v1[3], state->v1[2], result1);
+        state->v0[0] = result0[0];
+        state->v0[1] = result0[1];
+        state->v0[2] = result1[0];
+        state->v0[3] = result1[1];
+
+        hh_zipper_merge(state->v0[1], state->v0[0], result0);
+        hh_zipper_merge(state->v0[3], state->v0[2], result1);
+        state->v1[0] = result0[0];
+        state->v1[1] = result0[1];
+        state->v1[2] = result1[0];
+        state->v1[3] = result1[1];
+    }
+}
+
+/* HighwayHash PermuteAndUpdate */
+static void hh_permute_and_update(hh_state *state)
+{
+    uint64_t lanes[HH_LANES];
+    lanes[0] = hh_rotl64(state->v0[0], 20) ^ state->v1[0];
+    lanes[1] = hh_rotl64(state->v0[1], 21) ^ state->v1[1];
+    lanes[2] = hh_rotl64(state->v0[2], 22) ^ state->v1[2];
+    lanes[3] = hh_rotl64(state->v0[3], 23) ^ state->v1[3];
+    hh_update(lanes, state);
+}
+
+/* Initialize HighwayHash state with key */
+static void hh_reset(const uint64_t key[4], hh_state *state)
+{
+    int i;
+    for (i = 0; i < HH_LANES; ++i) {
+        state->mul0[i] = HH_INIT0[i] ^ key[i % 4];
+        state->mul1[i] = HH_INIT1[i] ^ key[i % 4];
+        state->v0[i] = state->mul0[i];
+        state->v1[i] = state->mul1[i];
+    }
+}
+
+/* Process remaining bytes (less than 32) */
+static void hh_update_remainder(const char *bytes, size_t size_mod32, hh_state *state)
+{
+    char packet[32];
+    uint64_t lanes[HH_LANES];
+    int i;
+    
+    /* Clear packet and copy remaining bytes */
+    memset(packet, 0, 32);
+    memcpy(packet, bytes, size_mod32);
+    
+    /* Set the size in the last byte */
+    packet[31] = (char)size_mod32;
+
+    /* Convert to lanes */
+    for (i = 0; i < HH_LANES; ++i) {
+        lanes[i] = hh_fetch64(packet + i * 8);
+    }
+    
+    hh_update(lanes, state);
+}
+
+/* HighwayHash main computation */
+static void hh_highway_hash(const uint64_t key[4], const char *bytes, size_t size, hh_state *state)
+{
+    size_t remainder = size & 31;
+    size_t truncated_size = size - remainder;
+    size_t i;
+    uint64_t lanes[HH_LANES];
+    int j;
+
+    hh_reset(key, state);
+
+    /* Process 32-byte chunks */
+    for (i = 0; i < truncated_size; i += 32) {
+        for (j = 0; j < HH_LANES; ++j) {
+            lanes[j] = hh_fetch64(bytes + i + j * 8);
+        }
+        hh_update(lanes, state);
+    }
+
+    /* Process remainder */
+    if (remainder != 0) {
+        hh_update_remainder(bytes + truncated_size, remainder, state);
+    }
+}
+
+/* Finalize 64-bit hash */
+static uint64_t hh_finalize64(hh_state *state)
+{
+    int i;
+    for (i = 0; i < 4; ++i) {
+        hh_permute_and_update(state);
+    }
+    return state->v0[0] + state->v1[0] + state->mul0[0] + state->mul1[0];
+}
+
+/* Finalize 128-bit hash */
+static void hh_finalize128(hh_state *state, uint64_t hash[2])
+{
+    int i;
+    for (i = 0; i < 6; ++i) {
+        hh_permute_and_update(state);
+    }
+    hash[0] = state->v0[0] + state->mul0[0] + state->v1[2] + state->mul1[2];
+    hash[1] = state->v0[1] + state->mul0[1] + state->v1[3] + state->mul1[3];
+}
+
+/* Finalize 256-bit hash */
+static void hh_finalize256(hh_state *state, uint64_t hash[4])
+{
+    int i;
+    for (i = 0; i < 10; ++i) {
+        hh_permute_and_update(state);
+    }
+    
+    /* Modular reduction from 1024 to 256 bits */
+    for (i = 0; i < HH_LANES; ++i) {
+        hash[i] = state->v0[i] + state->v1[i] + state->mul0[i] + state->mul1[i];
+    }
+}
+
+/* Default key for functions without explicit key */
+static const uint64_t HH_DEFAULT_KEY[4] = {
+    0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL,
+    0x1716151413121110ULL, 0x1F1E1D1C1B1A1918ULL
+};
+
+/* PostgreSQL function wrappers for HighwayHash64 */
+
+/* HighwayHash64 for text input with default key */
+PG_FUNCTION_INFO_V1(highwayhash64_text);
+
+Datum
+highwayhash64_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    hh_state state;
+    uint64_t hash;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, data, len, &state);
+    hash = hh_finalize64(&state);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* HighwayHash64 for text input with custom key (4 bigint values) */
+PG_FUNCTION_INFO_V1(highwayhash64_text_key);
+
+Datum
+highwayhash64_text_key(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, data, len, &state);
+    hash = hh_finalize64(&state);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* HighwayHash64 for bytea input with default key */
+PG_FUNCTION_INFO_V1(highwayhash64_bytea);
+
+Datum
+highwayhash64_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    hh_state state;
+    uint64_t hash;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, data, len, &state);
+    hash = hh_finalize64(&state);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* HighwayHash64 for bytea input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash64_bytea_key);
+
+Datum
+highwayhash64_bytea_key(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, data, len, &state);
+    hash = hh_finalize64(&state);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* HighwayHash64 for integer input with default key */
+PG_FUNCTION_INFO_V1(highwayhash64_int);
+
+Datum
+highwayhash64_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    hh_state state;
+    uint64_t hash;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, (char*)&input, sizeof(int32_t), &state);
+    hash = hh_finalize64(&state);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* HighwayHash64 for integer input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash64_int_key);
+
+Datum
+highwayhash64_int_key(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, (char*)&input, sizeof(int32_t), &state);
+    hash = hh_finalize64(&state);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* PostgreSQL function wrappers for HighwayHash128 */
+
+/* HighwayHash128 for text input with default key - returns array of two bigints */
+PG_FUNCTION_INFO_V1(highwayhash128_text);
+
+Datum
+highwayhash128_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    hh_state state;
+    uint64_t hash[2];
+    Datum result[2];
+    ArrayType *array;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, data, len, &state);
+    hh_finalize128(&state, hash);
+    
+    result[0] = Int64GetDatum((int64_t)hash[0]);
+    result[1] = Int64GetDatum((int64_t)hash[1]);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash128 for text input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash128_text_key);
+
+Datum
+highwayhash128_text_key(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash[2];
+    Datum result[2];
+    ArrayType *array;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, data, len, &state);
+    hh_finalize128(&state, hash);
+    
+    result[0] = Int64GetDatum((int64_t)hash[0]);
+    result[1] = Int64GetDatum((int64_t)hash[1]);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash128 for bytea input with default key */
+PG_FUNCTION_INFO_V1(highwayhash128_bytea);
+
+Datum
+highwayhash128_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    hh_state state;
+    uint64_t hash[2];
+    Datum result[2];
+    ArrayType *array;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, data, len, &state);
+    hh_finalize128(&state, hash);
+    
+    result[0] = Int64GetDatum((int64_t)hash[0]);
+    result[1] = Int64GetDatum((int64_t)hash[1]);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash128 for bytea input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash128_bytea_key);
+
+Datum
+highwayhash128_bytea_key(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash[2];
+    Datum result[2];
+    ArrayType *array;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, data, len, &state);
+    hh_finalize128(&state, hash);
+    
+    result[0] = Int64GetDatum((int64_t)hash[0]);
+    result[1] = Int64GetDatum((int64_t)hash[1]);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash128 for integer input with default key */
+PG_FUNCTION_INFO_V1(highwayhash128_int);
+
+Datum
+highwayhash128_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    hh_state state;
+    uint64_t hash[2];
+    Datum result[2];
+    ArrayType *array;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, (char*)&input, sizeof(int32_t), &state);
+    hh_finalize128(&state, hash);
+    
+    result[0] = Int64GetDatum((int64_t)hash[0]);
+    result[1] = Int64GetDatum((int64_t)hash[1]);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash128 for integer input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash128_int_key);
+
+Datum
+highwayhash128_int_key(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash[2];
+    Datum result[2];
+    ArrayType *array;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, (char*)&input, sizeof(int32_t), &state);
+    hh_finalize128(&state, hash);
+    
+    result[0] = Int64GetDatum((int64_t)hash[0]);
+    result[1] = Int64GetDatum((int64_t)hash[1]);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* PostgreSQL function wrappers for HighwayHash256 */
+
+/* HighwayHash256 for text input with default key - returns array of four bigints */
+PG_FUNCTION_INFO_V1(highwayhash256_text);
+
+Datum
+highwayhash256_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    hh_state state;
+    uint64_t hash[4];
+    Datum result[4];
+    ArrayType *array;
+    int i;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, data, len, &state);
+    hh_finalize256(&state, hash);
+    
+    for (i = 0; i < 4; ++i) {
+        result[i] = Int64GetDatum((int64_t)hash[i]);
+    }
+    
+    array = construct_array(result, 4, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash256 for text input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash256_text_key);
+
+Datum
+highwayhash256_text_key(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash[4];
+    Datum result[4];
+    ArrayType *array;
+    int i;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, data, len, &state);
+    hh_finalize256(&state, hash);
+    
+    for (i = 0; i < 4; ++i) {
+        result[i] = Int64GetDatum((int64_t)hash[i]);
+    }
+    
+    array = construct_array(result, 4, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash256 for bytea input with default key */
+PG_FUNCTION_INFO_V1(highwayhash256_bytea);
+
+Datum
+highwayhash256_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    hh_state state;
+    uint64_t hash[4];
+    Datum result[4];
+    ArrayType *array;
+    int i;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, data, len, &state);
+    hh_finalize256(&state, hash);
+    
+    for (i = 0; i < 4; ++i) {
+        result[i] = Int64GetDatum((int64_t)hash[i]);
+    }
+    
+    array = construct_array(result, 4, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash256 for bytea input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash256_bytea_key);
+
+Datum
+highwayhash256_bytea_key(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash[4];
+    Datum result[4];
+    ArrayType *array;
+    int i;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, data, len, &state);
+    hh_finalize256(&state, hash);
+    
+    for (i = 0; i < 4; ++i) {
+        result[i] = Int64GetDatum((int64_t)hash[i]);
+    }
+    
+    array = construct_array(result, 4, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash256 for integer input with default key */
+PG_FUNCTION_INFO_V1(highwayhash256_int);
+
+Datum
+highwayhash256_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    hh_state state;
+    uint64_t hash[4];
+    Datum result[4];
+    ArrayType *array;
+    int i;
+    
+    hh_highway_hash(HH_DEFAULT_KEY, (char*)&input, sizeof(int32_t), &state);
+    hh_finalize256(&state, hash);
+    
+    for (i = 0; i < 4; ++i) {
+        result[i] = Int64GetDatum((int64_t)hash[i]);
+    }
+    
+    array = construct_array(result, 4, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* HighwayHash256 for integer input with custom key */
+PG_FUNCTION_INFO_V1(highwayhash256_int_key);
+
+Datum
+highwayhash256_int_key(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t key0 = PG_GETARG_INT64(1);
+    int64_t key1 = PG_GETARG_INT64(2);
+    int64_t key2 = PG_GETARG_INT64(3);
+    int64_t key3 = PG_GETARG_INT64(4);
+    uint64_t key[4];
+    hh_state state;
+    uint64_t hash[4];
+    Datum result[4];
+    ArrayType *array;
+    int i;
+    
+    key[0] = (uint64_t)key0;
+    key[1] = (uint64_t)key1;
+    key[2] = (uint64_t)key2;
+    key[3] = (uint64_t)key3;
+    
+    hh_highway_hash(key, (char*)&input, sizeof(int32_t), &state);
+    hh_finalize256(&state, hash);
+    
+    for (i = 0; i < 4; ++i) {
+        result[i] = Int64GetDatum((int64_t)hash[i]);
+    }
+    
+    array = construct_array(result, 4, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}

--- a/tests/expected/highwayhash128.out
+++ b/tests/expected/highwayhash128.out
@@ -1,0 +1,146 @@
+-- Test basic hash functionality with text
+SELECT highwayhash128('hello world');
+               highwayhash128               
+--------------------------------------------
+ {-9002307960715477272,6897575193667018684}
+(1 row)
+
+-- Test hash with different text inputs
+SELECT highwayhash128('test string');
+              highwayhash128               
+-------------------------------------------
+ {8790480909741334366,6896986531429733706}
+(1 row)
+
+SELECT highwayhash128('another test');
+               highwayhash128               
+--------------------------------------------
+ {8750845589835017075,-3322922193145760634}
+(1 row)
+
+-- Test text input with custom key (4 bigint values)
+SELECT highwayhash128('hello world', 1, 2, 3, 4);
+               highwayhash128               
+--------------------------------------------
+ {-7700241520037866853,5736295513518689358}
+(1 row)
+
+SELECT highwayhash128('hello world', 42, 84, 168, 336);
+              highwayhash128               
+-------------------------------------------
+ {9185465481520367157,6499493138150571029}
+(1 row)
+
+-- Test bytea input
+SELECT highwayhash128('hello world'::bytea);
+               highwayhash128               
+--------------------------------------------
+ {-9002307960715477272,6897575193667018684}
+(1 row)
+
+-- Test bytea input with custom key
+SELECT highwayhash128('hello world'::bytea, 1, 2, 3, 4);
+               highwayhash128               
+--------------------------------------------
+ {-7700241520037866853,5736295513518689358}
+(1 row)
+
+-- Test integer input
+SELECT highwayhash128(12345);
+             highwayhash128              
+-----------------------------------------
+ {84525206629202176,7442391580945017510}
+(1 row)
+
+SELECT highwayhash128(-12345);
+             highwayhash128              
+-----------------------------------------
+ {84608127624122420,7442391580944332183}
+(1 row)
+
+-- Test integer input with custom key
+SELECT highwayhash128(12345, 1, 2, 3, 4);
+              highwayhash128               
+-------------------------------------------
+ {1101827263166064017,5877542203892655696}
+(1 row)
+
+SELECT highwayhash128(-12345, 42, 84, 168, 336);
+             highwayhash128              
+-----------------------------------------
+ {59931498248258631,7488800884916746726}
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT highwayhash128('consistent test') = highwayhash128('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test key effect (same input, different keys should give different hashes)
+SELECT highwayhash128('key test', 1, 2, 3, 4) != highwayhash128('key test', 5, 6, 7, 8);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT highwayhash128('');
+               highwayhash128               
+--------------------------------------------
+ {-8830773993745385472,4591297386336765809}
+(1 row)
+
+-- Test single character
+SELECT highwayhash128('a');
+             highwayhash128              
+-----------------------------------------
+ {-6068668903039879,7720386185158543736}
+(1 row)
+
+-- Test long string
+SELECT highwayhash128('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+               highwayhash128               
+--------------------------------------------
+ {-8597214559374803647,-629738111796056425}
+(1 row)
+
+-- Test array access (128-bit hash returns array of two bigints)
+SELECT 
+    (highwayhash128('hello world'))[1] AS first_64_bits,
+    (highwayhash128('hello world'))[2] AS second_64_bits;
+    first_64_bits     |   second_64_bits    
+----------------------+---------------------
+ -9002307960715477272 | 6897575193667018684
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'highwayhash128'
+ORDER BY proname, proargtypes;
+    proname     | provolatile | proisstrict 
+----------------+-------------+-------------
+ highwayhash128 | i           | t
+ highwayhash128 | i           | t
+ highwayhash128 | i           | t
+ highwayhash128 | i           | t
+ highwayhash128 | i           | t
+ highwayhash128 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/highwayhash256.out
+++ b/tests/expected/highwayhash256.out
@@ -1,0 +1,148 @@
+-- Test basic hash functionality with text
+SELECT highwayhash256('hello world');
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-1730180435067276230,-3949562583220325914,-8175018380205084287,4467081750962237455}
+(1 row)
+
+-- Test hash with different text inputs
+SELECT highwayhash256('test string');
+                                   highwayhash256                                    
+-------------------------------------------------------------------------------------
+ {3858991136825594713,-2636551026385740561,-8175018380205084287,4467081750962237455}
+(1 row)
+
+SELECT highwayhash256('another test');
+                                   highwayhash256                                    
+-------------------------------------------------------------------------------------
+ {3801096836107472628,-1545063077951306913,-8172580620705552195,4238699032901035705}
+(1 row)
+
+-- Test text input with custom key (4 bigint values)
+SELECT highwayhash256('hello world', 1, 2, 3, 4);
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-4953805049862479110,-2767360660977790659,-6676300237301038481,4855213622678204318}
+(1 row)
+
+SELECT highwayhash256('hello world', 42, 84, 168, 336);
+                                   highwayhash256                                    
+-------------------------------------------------------------------------------------
+ {8835603004757085333,-3603589079149553567,-7373579239990792827,6134616243185709516}
+(1 row)
+
+-- Test bytea input
+SELECT highwayhash256('hello world'::bytea);
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-1730180435067276230,-3949562583220325914,-8175018380205084287,4467081750962237455}
+(1 row)
+
+-- Test bytea input with custom key
+SELECT highwayhash256('hello world'::bytea, 1, 2, 3, 4);
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-4953805049862479110,-2767360660977790659,-6676300237301038481,4855213622678204318}
+(1 row)
+
+-- Test integer input
+SELECT highwayhash256(12345);
+                                   highwayhash256                                    
+-------------------------------------------------------------------------------------
+ {8857777780853903552,-2169319722197122402,-7947405037538532870,5435815990628376663}
+(1 row)
+
+SELECT highwayhash256(-12345);
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-4076967497944337203,-2564921235915593642,-7947405037538532870,5435815990628376663}
+(1 row)
+
+-- Test integer input with custom key
+SELECT highwayhash256(12345, 1, 2, 3, 4);
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-4259465054599662434,-4300662001544254925,-7416377129267376721,7462320350847369240}
+(1 row)
+
+SELECT highwayhash256(-12345, 42, 84, 168, 336);
+                                    highwayhash256                                    
+--------------------------------------------------------------------------------------
+ {-4564642586059109791,-4832600429236788342,-7038124027978908498,8425175342259426061}
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT highwayhash256('consistent test') = highwayhash256('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test key effect (same input, different keys should give different hashes)
+SELECT highwayhash256('key test', 1, 2, 3, 4) != highwayhash256('key test', 5, 6, 7, 8);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT highwayhash256('');
+                                   highwayhash256                                    
+-------------------------------------------------------------------------------------
+ {4237441290697061510,4239799407410372446,-5519670697284979940,-8684412929500817881}
+(1 row)
+
+-- Test single character
+SELECT highwayhash256('a');
+                                   highwayhash256                                    
+-------------------------------------------------------------------------------------
+ {-6811226016548761671,-675444791232094067,-7898651120030753058,4907017311289232543}
+(1 row)
+
+-- Test long string
+SELECT highwayhash256('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+                                   highwayhash256                                   
+------------------------------------------------------------------------------------
+ {8164782398116081581,3137452388839081006,-7331589830855910857,6016630088099183836}
+(1 row)
+
+-- Test array access (256-bit hash returns array of four bigints)
+SELECT 
+    (highwayhash256('hello world'))[1] AS first_64_bits,
+    (highwayhash256('hello world'))[2] AS second_64_bits,
+    (highwayhash256('hello world'))[3] AS third_64_bits,
+    (highwayhash256('hello world'))[4] AS fourth_64_bits;
+    first_64_bits     |    second_64_bits    |    third_64_bits     |   fourth_64_bits    
+----------------------+----------------------+----------------------+---------------------
+ -1730180435067276230 | -3949562583220325914 | -8175018380205084287 | 4467081750962237455
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'highwayhash256'
+ORDER BY proname, proargtypes;
+    proname     | provolatile | proisstrict 
+----------------+-------------+-------------
+ highwayhash256 | i           | t
+ highwayhash256 | i           | t
+ highwayhash256 | i           | t
+ highwayhash256 | i           | t
+ highwayhash256 | i           | t
+ highwayhash256 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/highwayhash64.out
+++ b/tests/expected/highwayhash64.out
@@ -1,0 +1,137 @@
+-- Test basic hash functionality with text
+SELECT highwayhash64('hello world');
+   highwayhash64   
+-------------------
+ 55764245668984757
+(1 row)
+
+-- Test hash with different text inputs
+SELECT highwayhash64('test string');
+    highwayhash64     
+----------------------
+ -2758813447935032806
+(1 row)
+
+SELECT highwayhash64('another test');
+    highwayhash64     
+----------------------
+ -5929280350065762128
+(1 row)
+
+-- Test text input with custom key (4 bigint values)
+SELECT highwayhash64('hello world', 1, 2, 3, 4);
+    highwayhash64     
+----------------------
+ -5132475355195403677
+(1 row)
+
+SELECT highwayhash64('hello world', 42, 84, 168, 336);
+    highwayhash64     
+----------------------
+ -1733841754863656890
+(1 row)
+
+-- Test bytea input
+SELECT highwayhash64('hello world'::bytea);
+   highwayhash64   
+-------------------
+ 55764245668984757
+(1 row)
+
+-- Test bytea input with custom key
+SELECT highwayhash64('hello world'::bytea, 1, 2, 3, 4);
+    highwayhash64     
+----------------------
+ -5132475355195403677
+(1 row)
+
+-- Test integer input
+SELECT highwayhash64(12345);
+    highwayhash64     
+----------------------
+ -7518841419134855576
+(1 row)
+
+SELECT highwayhash64(-12345);
+    highwayhash64     
+----------------------
+ -5740664418722816357
+(1 row)
+
+-- Test integer input with custom key
+SELECT highwayhash64(12345, 1, 2, 3, 4);
+    highwayhash64     
+----------------------
+ -8099601468883049044
+(1 row)
+
+SELECT highwayhash64(-12345, 42, 84, 168, 336);
+    highwayhash64     
+----------------------
+ -2934896199736069178
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT highwayhash64('consistent test') = highwayhash64('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test key effect (same input, different keys should give different hashes)
+SELECT highwayhash64('key test', 1, 2, 3, 4) != highwayhash64('key test', 5, 6, 7, 8);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT highwayhash64('');
+    highwayhash64    
+---------------------
+ 1606382020167941598
+(1 row)
+
+-- Test single character
+SELECT highwayhash64('a');
+    highwayhash64    
+---------------------
+ -994871913435693176
+(1 row)
+
+-- Test long string
+SELECT highwayhash64('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+    highwayhash64     
+----------------------
+ -1108139000475772666
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'highwayhash64'
+ORDER BY proname, proargtypes;
+    proname    | provolatile | proisstrict 
+---------------+-------------+-------------
+ highwayhash64 | i           | t
+ highwayhash64 | i           | t
+ highwayhash64 | i           | t
+ highwayhash64 | i           | t
+ highwayhash64 | i           | t
+ highwayhash64 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/sql/highwayhash128.sql
+++ b/tests/sql/highwayhash128.sql
@@ -1,0 +1,60 @@
+-- Test basic hash functionality with text
+SELECT highwayhash128('hello world');
+
+-- Test hash with different text inputs
+SELECT highwayhash128('test string');
+SELECT highwayhash128('another test');
+
+-- Test text input with custom key (4 bigint values)
+SELECT highwayhash128('hello world', 1, 2, 3, 4);
+SELECT highwayhash128('hello world', 42, 84, 168, 336);
+
+-- Test bytea input
+SELECT highwayhash128('hello world'::bytea);
+
+-- Test bytea input with custom key
+SELECT highwayhash128('hello world'::bytea, 1, 2, 3, 4);
+
+-- Test integer input
+SELECT highwayhash128(12345);
+SELECT highwayhash128(-12345);
+
+-- Test integer input with custom key
+SELECT highwayhash128(12345, 1, 2, 3, 4);
+SELECT highwayhash128(-12345, 42, 84, 168, 336);
+
+-- Test consistency (same input should give same hash)
+SELECT highwayhash128('consistent test') = highwayhash128('consistent test');
+
+-- Test key effect (same input, different keys should give different hashes)
+SELECT highwayhash128('key test', 1, 2, 3, 4) != highwayhash128('key test', 5, 6, 7, 8);
+
+-- Test empty string
+SELECT highwayhash128('');
+
+-- Test single character
+SELECT highwayhash128('a');
+
+-- Test long string
+SELECT highwayhash128('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test array access (128-bit hash returns array of two bigints)
+SELECT 
+    (highwayhash128('hello world'))[1] AS first_64_bits,
+    (highwayhash128('hello world'))[2] AS second_64_bits;
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'highwayhash128'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/highwayhash256.sql
+++ b/tests/sql/highwayhash256.sql
@@ -1,0 +1,62 @@
+-- Test basic hash functionality with text
+SELECT highwayhash256('hello world');
+
+-- Test hash with different text inputs
+SELECT highwayhash256('test string');
+SELECT highwayhash256('another test');
+
+-- Test text input with custom key (4 bigint values)
+SELECT highwayhash256('hello world', 1, 2, 3, 4);
+SELECT highwayhash256('hello world', 42, 84, 168, 336);
+
+-- Test bytea input
+SELECT highwayhash256('hello world'::bytea);
+
+-- Test bytea input with custom key
+SELECT highwayhash256('hello world'::bytea, 1, 2, 3, 4);
+
+-- Test integer input
+SELECT highwayhash256(12345);
+SELECT highwayhash256(-12345);
+
+-- Test integer input with custom key
+SELECT highwayhash256(12345, 1, 2, 3, 4);
+SELECT highwayhash256(-12345, 42, 84, 168, 336);
+
+-- Test consistency (same input should give same hash)
+SELECT highwayhash256('consistent test') = highwayhash256('consistent test');
+
+-- Test key effect (same input, different keys should give different hashes)
+SELECT highwayhash256('key test', 1, 2, 3, 4) != highwayhash256('key test', 5, 6, 7, 8);
+
+-- Test empty string
+SELECT highwayhash256('');
+
+-- Test single character
+SELECT highwayhash256('a');
+
+-- Test long string
+SELECT highwayhash256('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test array access (256-bit hash returns array of four bigints)
+SELECT 
+    (highwayhash256('hello world'))[1] AS first_64_bits,
+    (highwayhash256('hello world'))[2] AS second_64_bits,
+    (highwayhash256('hello world'))[3] AS third_64_bits,
+    (highwayhash256('hello world'))[4] AS fourth_64_bits;
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'highwayhash256'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/highwayhash64.sql
+++ b/tests/sql/highwayhash64.sql
@@ -1,0 +1,55 @@
+-- Test basic hash functionality with text
+SELECT highwayhash64('hello world');
+
+-- Test hash with different text inputs
+SELECT highwayhash64('test string');
+SELECT highwayhash64('another test');
+
+-- Test text input with custom key (4 bigint values)
+SELECT highwayhash64('hello world', 1, 2, 3, 4);
+SELECT highwayhash64('hello world', 42, 84, 168, 336);
+
+-- Test bytea input
+SELECT highwayhash64('hello world'::bytea);
+
+-- Test bytea input with custom key
+SELECT highwayhash64('hello world'::bytea, 1, 2, 3, 4);
+
+-- Test integer input
+SELECT highwayhash64(12345);
+SELECT highwayhash64(-12345);
+
+-- Test integer input with custom key
+SELECT highwayhash64(12345, 1, 2, 3, 4);
+SELECT highwayhash64(-12345, 42, 84, 168, 336);
+
+-- Test consistency (same input should give same hash)
+SELECT highwayhash64('consistent test') = highwayhash64('consistent test');
+
+-- Test key effect (same input, different keys should give different hashes)
+SELECT highwayhash64('key test', 1, 2, 3, 4) != highwayhash64('key test', 5, 6, 7, 8);
+
+-- Test empty string
+SELECT highwayhash64('');
+
+-- Test single character
+SELECT highwayhash64('a');
+
+-- Test long string
+SELECT highwayhash64('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 'highwayhash64'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Add HighwayHash functions (64, 128, 256 bits) to hashlib extension with support for text, bytea, and integer inputs; update README to include new algorithm details and usage examples