### PR TITLE
feat: add t1ha hash functions (t1ha0, t1ha1, t1ha2, t1ha2_128) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = hashlib
 MODULE_big = hashlib
 DATA = sql/hashlib--0.0.1.sql
-OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/farmhash.o src/highwayhash.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/metrohash.o src/murmur.o src/siphash24.o src/spookyhash.o src/xxhash.o
+OBJS = src/cityhash64.o src/cityhash128.o src/crc32.o src/farmhash.o src/highwayhash.o src/lookup2.o src/lookup3be.o src/lookup3le.o src/metrohash.o src/murmur.o src/siphash24.o src/spookyhash.o src/t1ha.o src/xxhash.o
 PG_CONFIG = pg_config
 
 # PGXN variables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pghashlib
 
-pghashlib is a PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, SipHash-2-4, SpookyHash, xxHash32, xxHash64, FarmHash32, FarmHash64, HighwayHash64, HighwayHash128, HighwayHash256, MetroHash64, MetroHash128, lookup2, lookup3be, and lookup3le algorithms.
+pghashlib is a PostgreSQL extension providing high-performance hash functions for data processing and analysis. Currently includes MurmurHash3, CRC32, CityHash64, CityHash128, SipHash-2-4, SpookyHash, xxHash32, xxHash64, FarmHash32, FarmHash64, HighwayHash64, HighwayHash128, HighwayHash256, MetroHash64, MetroHash128, t1ha0, t1ha1, t1ha2, t1ha2_128, lookup2, lookup3be, and lookup3le algorithms.
 
 ## Table of Contents
 
@@ -30,6 +30,10 @@ pghashlib is a PostgreSQL extension providing high-performance hash functions fo
    - [highwayhash256](#highwayhash256)
    - [metrohash64](#metrohash64)
    - [metrohash128](#metrohash128)
+   - [t1ha0](#t1ha0)
+   - [t1ha1](#t1ha1)
+   - [t1ha2](#t1ha2)
+   - [t1ha2_128](#t1ha2_128)
    - [lookup2](#lookup2)
    - [lookup3be](#lookup3be)
    - [lookup3le](#lookup3le)
@@ -145,6 +149,10 @@ CREATE EXTENSION hashlib;
 - **HighwayHash256**: Google's SIMD-optimized keyed hash function (256-bit) - maximum collision resistance
 - **MetroHash64**: Fast alternative with excellent avalanche properties (64-bit) - algorithmically generated for performance
 - **MetroHash128**: Fast alternative with excellent avalanche properties (128-bit) - strong statistical profile similar to MD5
+- **t1ha0**: Fastest available t1ha variant - automatically selects optimal implementation for current CPU
+- **t1ha1**: Baseline portable t1ha hash - stable across architectures with reasonable quality
+- **t1ha2**: Recommended t1ha variant - good quality for checksums and hash tables, optimized for 64-bit systems
+- **t1ha2_128**: 128-bit version of t1ha2 - provides extended hash length for collision resistance
 - **lookup2**: Bob Jenkins' lookup2 hash function - fast and well-distributed
 - **lookup3be**: Bob Jenkins' lookup3 hash function with big-endian byte order - improved version of lookup2
 - **lookup3le**: Bob Jenkins' lookup3 hash function with little-endian byte order - optimized for Intel/AMD systems
@@ -173,6 +181,10 @@ CREATE EXTENSION hashlib;
 | `highwayhash256` | `text`, `bytea`, `integer` | Yes (4 keys) | `bigint[]` | 256-bit HighwayHash - returns array of four 64-bit values |
 | `metrohash64` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit MetroHash - fast alternative with excellent avalanche properties |
 | `metrohash128` | `text`, `bytea`, `integer` | Yes | `bigint[]` | 128-bit MetroHash - returns array of two 64-bit values |
+| `t1ha0` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit t1ha0 - fastest available t1ha variant for current CPU |
+| `t1ha1` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit t1ha1 - baseline portable hash with stable results |
+| `t1ha2` | `text`, `bytea`, `integer` | Yes | `bigint` | 64-bit t1ha2 - recommended variant optimized for 64-bit systems |
+| `t1ha2_128` | `text`, `bytea`, `integer` | Yes | `bigint[]` | 128-bit t1ha2 - returns array of two 64-bit values |
 | `lookup2` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup2 - Bob Jenkins' hash function |
 | `lookup3be` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3be - Bob Jenkins' lookup3 with big-endian order |
 | `lookup3le` | `text`, `bytea`, `integer` | Yes | `integer` | 32-bit lookup3le - Bob Jenkins' lookup3 with little-endian order |
@@ -904,6 +916,172 @@ SELECT
 
 </details>
 
+### t1ha0
+
+t1ha0 is the fastest available variant of the t1ha (Fast Positive Hash) family. It automatically selects the optimal implementation for the current CPU architecture, prioritizing speed over consistent cross-platform results.
+
+**Signatures:**
+- `t1ha0(text)` → `bigint`
+- `t1ha0(text, bigint)` → `bigint`
+- `t1ha0(bytea)` → `bigint`
+- `t1ha0(bytea, bigint)` → `bigint`
+- `t1ha0(integer)` → `bigint`
+- `t1ha0(integer, bigint)` → `bigint`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Seed value (default: 0)
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default seed
+SELECT t1ha0('hello world');
+-- Result: Ultra-fast 64-bit t1ha0 hash
+
+-- Hash text with custom seed
+SELECT t1ha0('hello world', 42);
+-- Result: Ultra-fast 64-bit t1ha0 hash with custom seed
+
+-- Hash bytea data
+SELECT t1ha0('hello world'::bytea);
+-- Result: Ultra-fast 64-bit t1ha0 hash of bytea data
+
+-- Hash integer values
+SELECT t1ha0(12345);
+-- Result: Ultra-fast 64-bit t1ha0 hash of integer
+```
+
+</details>
+
+### t1ha1
+
+t1ha1 is the baseline portable variant of t1ha, providing stable results across different architectures with reasonable quality for checksums and hash tables.
+
+**Signatures:**
+- `t1ha1(text)` → `bigint`
+- `t1ha1(text, bigint)` → `bigint`
+- `t1ha1(bytea)` → `bigint`
+- `t1ha1(bytea, bigint)` → `bigint`
+- `t1ha1(integer)` → `bigint`
+- `t1ha1(integer, bigint)` → `bigint`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Seed value (default: 0)
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default seed
+SELECT t1ha1('hello world');
+-- Result: Portable 64-bit t1ha1 hash
+
+-- Hash text with custom seed
+SELECT t1ha1('hello world', 42);
+-- Result: Portable 64-bit t1ha1 hash with custom seed
+
+-- Hash bytea data
+SELECT t1ha1('hello world'::bytea);
+-- Result: Portable 64-bit t1ha1 hash of bytea data
+
+-- Hash integer values
+SELECT t1ha1(12345);
+-- Result: Portable 64-bit t1ha1 hash of integer
+```
+
+</details>
+
+### t1ha2
+
+t1ha2 is the recommended variant of t1ha, providing good quality for checksums and hash tables while being optimized for 64-bit systems. It offers the best balance of speed and quality.
+
+**Signatures:**
+- `t1ha2(text)` → `bigint`
+- `t1ha2(text, bigint)` → `bigint`
+- `t1ha2(bytea)` → `bigint`
+- `t1ha2(bytea, bigint)` → `bigint`
+- `t1ha2(integer)` → `bigint`
+- `t1ha2(integer, bigint)` → `bigint`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Seed value (default: 0)
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default seed
+SELECT t1ha2('hello world');
+-- Result: High-quality 64-bit t1ha2 hash
+
+-- Hash text with custom seed
+SELECT t1ha2('hello world', 42);
+-- Result: High-quality 64-bit t1ha2 hash with custom seed
+
+-- Hash bytea data
+SELECT t1ha2('hello world'::bytea);
+-- Result: High-quality 64-bit t1ha2 hash of bytea data
+
+-- Hash integer values
+SELECT t1ha2(12345);
+-- Result: High-quality 64-bit t1ha2 hash of integer
+```
+
+</details>
+
+### t1ha2_128
+
+t1ha2_128 is the 128-bit version of t1ha2, providing extended hash length for applications requiring higher collision resistance while maintaining the performance characteristics of t1ha2.
+
+**Signatures:**
+- `t1ha2_128(text)` → `bigint[]`
+- `t1ha2_128(text, bigint)` → `bigint[]`
+- `t1ha2_128(bytea)` → `bigint[]`
+- `t1ha2_128(bytea, bigint)` → `bigint[]`
+- `t1ha2_128(integer)` → `bigint[]`
+- `t1ha2_128(integer, bigint)` → `bigint[]`
+
+**Parameters:**
+- First parameter: Input data to hash (`text`, `bytea`, or `integer`)
+- Second parameter (optional): Seed value (default: 0)
+
+**Return Value:**
+Returns an array of two `bigint` values representing the 128-bit hash:
+- `[1]`: First 64 bits of the hash
+- `[2]`: Second 64 bits of the hash
+
+<details>
+<summary><strong>Examples</strong></summary>
+
+```sql
+-- Hash text with default seed
+SELECT t1ha2_128('hello world');
+-- Result: {first_64_bits, second_64_bits}
+
+-- Hash text with custom seed
+SELECT t1ha2_128('hello world', 42);
+-- Result: High-quality 128-bit t1ha2 hash with custom seed
+
+-- Hash bytea data
+SELECT t1ha2_128('hello world'::bytea);
+-- Result: High-quality 128-bit t1ha2 hash of bytea data
+
+-- Hash integer values
+SELECT t1ha2_128(12345);
+-- Result: High-quality 128-bit t1ha2 hash of integer
+
+-- Access individual parts of the 128-bit hash
+SELECT 
+    (t1ha2_128('hello world'))[1] AS first_64_bits,
+    (t1ha2_128('hello world'))[2] AS second_64_bits;
+```
+
+</details>
+
 ### lookup2
 
 lookup2 is Bob Jenkins' hash function, designed for fast hashing with good distribution properties.
@@ -1244,7 +1422,7 @@ Additional non-cryptographic hash functions planned for future releases:
 
 ### **Medium Priority**
 - [x] **MetroHash** - Fast alternative with good avalanche properties
-- [ ] **t1ha** - Fast Positive Hash optimized for x86-64
+- [x] **t1ha** - Fast Positive Hash optimized for x86-64
 - [ ] **wyhash** - Simple, fast implementation
 
 ### **Specialized**

--- a/sql/hashlib--0.0.1.sql
+++ b/sql/hashlib--0.0.1.sql
@@ -702,3 +702,147 @@ CREATE OR REPLACE FUNCTION metrohash128(integer, bigint)
 RETURNS bigint[]
 AS 'MODULE_PATHNAME', 'metrohash128_int_seed'
 LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha0 function for text (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha0(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha0_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha0 function for text with custom seed
+CREATE OR REPLACE FUNCTION t1ha0(text, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha0_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha0 function for bytea (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha0(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha0_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha0 function for bytea with custom seed
+CREATE OR REPLACE FUNCTION t1ha0(bytea, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha0_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha0 function for integer (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha0(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha0_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha0 function for integer with custom seed
+CREATE OR REPLACE FUNCTION t1ha0(integer, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha0_int_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha1 function for text (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha1(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha1_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha1 function for text with custom seed
+CREATE OR REPLACE FUNCTION t1ha1(text, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha1_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha1 function for bytea (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha1(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha1_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha1 function for bytea with custom seed
+CREATE OR REPLACE FUNCTION t1ha1(bytea, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha1_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha1 function for integer (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha1(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha1_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha1 function for integer with custom seed
+CREATE OR REPLACE FUNCTION t1ha1(integer, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha1_int_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2 function for text (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha2(text)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha2_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2 function for text with custom seed
+CREATE OR REPLACE FUNCTION t1ha2(text, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha2_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2 function for bytea (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha2(bytea)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha2_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2 function for bytea with custom seed
+CREATE OR REPLACE FUNCTION t1ha2(bytea, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha2_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2 function for integer (default seed = 0)
+CREATE OR REPLACE FUNCTION t1ha2(integer)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha2_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2 function for integer with custom seed
+CREATE OR REPLACE FUNCTION t1ha2(integer, bigint)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 't1ha2_int_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2_128 function for text (default seed = 0) - returns array of two bigints
+CREATE OR REPLACE FUNCTION t1ha2_128(text)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 't1ha2_128_text'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2_128 function for text with custom seed - returns array of two bigints
+CREATE OR REPLACE FUNCTION t1ha2_128(text, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 't1ha2_128_text_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2_128 function for bytea (default seed = 0) - returns array of two bigints
+CREATE OR REPLACE FUNCTION t1ha2_128(bytea)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 't1ha2_128_bytea'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2_128 function for bytea with custom seed - returns array of two bigints
+CREATE OR REPLACE FUNCTION t1ha2_128(bytea, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 't1ha2_128_bytea_seed'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2_128 function for integer (default seed = 0) - returns array of two bigints
+CREATE OR REPLACE FUNCTION t1ha2_128(integer)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 't1ha2_128_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- t1ha2_128 function for integer with custom seed - returns array of two bigints
+CREATE OR REPLACE FUNCTION t1ha2_128(integer, bigint)
+RETURNS bigint[]
+AS 'MODULE_PATHNAME', 't1ha2_128_int_seed'
+LANGUAGE C IMMUTABLE STRICT;

--- a/src/t1ha.c
+++ b/src/t1ha.c
@@ -1,0 +1,699 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "utils/array.h"
+#include "catalog/pg_type.h"
+#include "mb/pg_wchar.h"
+#include "access/htup_details.h"
+
+/* t1ha constants */
+static const uint64_t t1ha_prime_0 = 0x9E3779B185EBCA87ULL;
+static const uint64_t t1ha_prime_1 = 0xC2B2AE3D27D4EB4FULL;
+static const uint64_t t1ha_prime_2 = 0x165667B19E3779F9ULL;
+static const uint64_t t1ha_prime_3 = 0x85EBCA77C2B2AE63ULL;
+static const uint64_t t1ha_prime_4 = 0x27D4EB2F165667C5ULL;
+static const uint64_t t1ha_prime_5 = 0x9E3779B185EBCA87ULL;
+static const uint64_t t1ha_prime_6 = 0xC2B2AE3D27D4EB4FULL;
+
+/* 128-bit hash result structure */
+typedef struct {
+    uint64_t low;
+    uint64_t high;
+} uint128_t;
+
+/* Utility functions */
+static uint64_t
+t1ha_fetch64(const char *p)
+{
+    uint64_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static uint32_t
+t1ha_fetch32(const char *p)
+{
+    uint32_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static uint16_t
+t1ha_fetch16(const char *p)
+{
+    uint16_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static uint64_t
+t1ha_rot64(uint64_t v, int s)
+{
+    return (v >> s) | (v << (64 - s));
+}
+
+static uint64_t
+t1ha_mix64(uint64_t v, uint64_t p)
+{
+    v *= p;
+    return v ^ t1ha_rot64(v, 41);
+}
+
+/* t1ha1 implementation */
+static uint64_t
+t1ha1_le(const char *data, size_t len, uint64_t seed)
+{
+    const char *ptr = data;
+    const char *end = data + len;
+    uint64_t a = seed;
+    uint64_t b = len;
+    
+    if (len >= 32)
+    {
+        uint64_t c = t1ha_rot64(len, 17) + seed;
+        uint64_t d = len ^ t1ha_rot64(seed, 17);
+        
+        do
+        {
+            uint64_t w0, w1, w2, w3;
+            w0 = t1ha_fetch64(ptr); ptr += 8;
+            w1 = t1ha_fetch64(ptr); ptr += 8;
+            w2 = t1ha_fetch64(ptr); ptr += 8;
+            w3 = t1ha_fetch64(ptr); ptr += 8;
+            
+            a ^= t1ha_mix64(w0, t1ha_prime_0);
+            b ^= t1ha_mix64(w1, t1ha_prime_1);
+            c ^= t1ha_mix64(w2, t1ha_prime_2);
+            d ^= t1ha_mix64(w3, t1ha_prime_3);
+        } while (ptr <= end - 32);
+        
+        a ^= t1ha_rot64(c, 17);
+        b ^= t1ha_rot64(d, 17);
+    }
+    
+    switch ((end - ptr) >> 3)
+    {
+        default:
+            break;
+        case 3:
+            {
+                uint64_t c = t1ha_fetch64(ptr); ptr += 8;
+                c *= t1ha_prime_2;
+                a ^= t1ha_rot64(c, 41);
+            }
+            /* fall through */
+        case 2:
+            b ^= t1ha_mix64(t1ha_fetch64(ptr), t1ha_prime_1);
+            ptr += 8;
+            /* fall through */
+        case 1:
+            a ^= t1ha_mix64(t1ha_fetch64(ptr), t1ha_prime_0);
+            ptr += 8;
+            /* fall through */
+        case 0:
+            switch (end - ptr)
+            {
+                case 7:
+                    b ^= (uint64_t)ptr[6] << 48;
+                    /* fall through */
+                case 6:
+                    b ^= (uint64_t)ptr[5] << 40;
+                    /* fall through */
+                case 5:
+                    b ^= (uint64_t)ptr[4] << 32;
+                    /* fall through */
+                case 4:
+                    b ^= t1ha_fetch32(ptr);
+                    break;
+                case 3:
+                    a ^= (uint64_t)ptr[2] << 16;
+                    /* fall through */
+                case 2:
+                    a ^= t1ha_fetch16(ptr);
+                    break;
+                case 1:
+                    a ^= ptr[0];
+                    break;
+            }
+    }
+    
+    /* Final mixing */
+    a *= t1ha_prime_4;
+    b *= t1ha_prime_5;
+    return t1ha_mix64(a ^ b, t1ha_prime_6);
+}
+
+/* t1ha2 implementation */
+static uint64_t
+t1ha2_atonce(const char *data, size_t len, uint64_t seed)
+{
+    const char *ptr = data;
+    const char *end = data + len;
+    uint64_t a, b, c, d;
+    
+    a = seed;
+    b = len;
+    c = t1ha_rot64(len, 17) + seed;
+    d = len ^ t1ha_rot64(seed, 17);
+    
+    if (len >= 32)
+    {
+        do
+        {
+            uint64_t w0, w1, w2, w3;
+            w0 = t1ha_fetch64(ptr); ptr += 8;
+            w1 = t1ha_fetch64(ptr); ptr += 8;
+            w2 = t1ha_fetch64(ptr); ptr += 8;
+            w3 = t1ha_fetch64(ptr); ptr += 8;
+            
+            a += w0 * t1ha_prime_0;
+            a = t1ha_rot64(a, 32);
+            b += w1 * t1ha_prime_1;
+            b = t1ha_rot64(b, 32);
+            c += w2 * t1ha_prime_2;
+            c = t1ha_rot64(c, 32);
+            d += w3 * t1ha_prime_3;
+            d = t1ha_rot64(d, 32);
+        } while (ptr <= end - 32);
+    }
+    
+    /* Handle remaining bytes */
+    if (ptr < end)
+    {
+        switch ((end - ptr) >> 3)
+        {
+            default:
+                break;
+            case 3:
+                c += t1ha_fetch64(ptr) * t1ha_prime_2;
+                ptr += 8;
+                /* fall through */
+            case 2:
+                b += t1ha_fetch64(ptr) * t1ha_prime_1;
+                ptr += 8;
+                /* fall through */
+            case 1:
+                a += t1ha_fetch64(ptr) * t1ha_prime_0;
+                ptr += 8;
+                /* fall through */
+            case 0:
+                switch (end - ptr)
+                {
+                    case 7:
+                        d += (uint64_t)ptr[6] << 48;
+                        /* fall through */
+                    case 6:
+                        d += (uint64_t)ptr[5] << 40;
+                        /* fall through */
+                    case 5:
+                        d += (uint64_t)ptr[4] << 32;
+                        /* fall through */
+                    case 4:
+                        d += t1ha_fetch32(ptr);
+                        break;
+                    case 3:
+                        c += (uint64_t)ptr[2] << 16;
+                        /* fall through */
+                    case 2:
+                        c += t1ha_fetch16(ptr);
+                        break;
+                    case 1:
+                        c += ptr[0];
+                        break;
+                }
+        }
+    }
+    
+    /* Final mixing */
+    a ^= t1ha_rot64(c, 17);
+    b ^= t1ha_rot64(d, 17);
+    c ^= t1ha_rot64(a, 17);
+    d ^= t1ha_rot64(b, 17);
+    
+    return t1ha_mix64(a + b, t1ha_prime_4) + t1ha_mix64(c + d, t1ha_prime_5);
+}
+
+/* t1ha2 128-bit implementation */
+static uint128_t
+t1ha2_atonce128(const char *data, size_t len, uint64_t seed)
+{
+    const char *ptr = data;
+    const char *end = data + len;
+    uint64_t a, b, c, d;
+    uint128_t result;
+    
+    a = seed;
+    b = len;
+    c = t1ha_rot64(len, 17) + seed;
+    d = len ^ t1ha_rot64(seed, 17);
+    
+    if (len >= 32)
+    {
+        do
+        {
+            uint64_t w0, w1, w2, w3;
+            w0 = t1ha_fetch64(ptr); ptr += 8;
+            w1 = t1ha_fetch64(ptr); ptr += 8;
+            w2 = t1ha_fetch64(ptr); ptr += 8;
+            w3 = t1ha_fetch64(ptr); ptr += 8;
+            
+            a += w0 * t1ha_prime_0;
+            a = t1ha_rot64(a, 32);
+            b += w1 * t1ha_prime_1;
+            b = t1ha_rot64(b, 32);
+            c += w2 * t1ha_prime_2;
+            c = t1ha_rot64(c, 32);
+            d += w3 * t1ha_prime_3;
+            d = t1ha_rot64(d, 32);
+        } while (ptr <= end - 32);
+    }
+    
+    /* Handle remaining bytes - same as t1ha2_atonce */
+    if (ptr < end)
+    {
+        switch ((end - ptr) >> 3)
+        {
+            default:
+                break;
+            case 3:
+                c += t1ha_fetch64(ptr) * t1ha_prime_2;
+                ptr += 8;
+                /* fall through */
+            case 2:
+                b += t1ha_fetch64(ptr) * t1ha_prime_1;
+                ptr += 8;
+                /* fall through */
+            case 1:
+                a += t1ha_fetch64(ptr) * t1ha_prime_0;
+                ptr += 8;
+                /* fall through */
+            case 0:
+                switch (end - ptr)
+                {
+                    case 7:
+                        d += (uint64_t)ptr[6] << 48;
+                        /* fall through */
+                    case 6:
+                        d += (uint64_t)ptr[5] << 40;
+                        /* fall through */
+                    case 5:
+                        d += (uint64_t)ptr[4] << 32;
+                        /* fall through */
+                    case 4:
+                        d += t1ha_fetch32(ptr);
+                        break;
+                    case 3:
+                        c += (uint64_t)ptr[2] << 16;
+                        /* fall through */
+                    case 2:
+                        c += t1ha_fetch16(ptr);
+                        break;
+                    case 1:
+                        c += ptr[0];
+                        break;
+                }
+        }
+    }
+    
+    /* Final mixing for 128-bit result */
+    a ^= t1ha_rot64(c, 17);
+    b ^= t1ha_rot64(d, 17);
+    c ^= t1ha_rot64(a, 17);
+    d ^= t1ha_rot64(b, 17);
+    
+    result.low = t1ha_mix64(a + b, t1ha_prime_4);
+    result.high = t1ha_mix64(c + d, t1ha_prime_5);
+    
+    return result;
+}
+
+/* t1ha0 - dispatcher (use t1ha2 as fastest available) */
+static uint64_t
+t1ha0(const char *data, size_t len, uint64_t seed)
+{
+    return t1ha2_atonce(data, len, seed);
+}
+
+/* PostgreSQL function wrappers for t1ha0 */
+
+/* t1ha0 for text input with default seed */
+PG_FUNCTION_INFO_V1(t1ha0_text);
+
+Datum
+t1ha0_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha0(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha0 for text input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha0_text_seed);
+
+Datum
+t1ha0_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha0(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha0 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(t1ha0_bytea);
+
+Datum
+t1ha0_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha0(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha0 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha0_bytea_seed);
+
+Datum
+t1ha0_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha0(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha0 for integer input with default seed */
+PG_FUNCTION_INFO_V1(t1ha0_int);
+
+Datum
+t1ha0_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash = t1ha0((char*)&input, sizeof(int32_t), 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha0 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha0_int_seed);
+
+Datum
+t1ha0_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    uint64_t hash = t1ha0((char*)&input, sizeof(int32_t), (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* PostgreSQL function wrappers for t1ha1 */
+
+/* t1ha1 for text input with default seed */
+PG_FUNCTION_INFO_V1(t1ha1_text);
+
+Datum
+t1ha1_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha1_le(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha1 for text input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha1_text_seed);
+
+Datum
+t1ha1_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha1_le(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha1 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(t1ha1_bytea);
+
+Datum
+t1ha1_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha1_le(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha1 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha1_bytea_seed);
+
+Datum
+t1ha1_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha1_le(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha1 for integer input with default seed */
+PG_FUNCTION_INFO_V1(t1ha1_int);
+
+Datum
+t1ha1_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash = t1ha1_le((char*)&input, sizeof(int32_t), 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha1 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha1_int_seed);
+
+Datum
+t1ha1_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    uint64_t hash = t1ha1_le((char*)&input, sizeof(int32_t), (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* PostgreSQL function wrappers for t1ha2 */
+
+/* t1ha2 for text input with default seed */
+PG_FUNCTION_INFO_V1(t1ha2_text);
+
+Datum
+t1ha2_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha2_atonce(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha2 for text input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha2_text_seed);
+
+Datum
+t1ha2_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha2_atonce(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha2 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(t1ha2_bytea);
+
+Datum
+t1ha2_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha2_atonce(data, len, 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha2 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha2_bytea_seed);
+
+Datum
+t1ha2_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint64_t hash = t1ha2_atonce(data, len, (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha2 for integer input with default seed */
+PG_FUNCTION_INFO_V1(t1ha2_int);
+
+Datum
+t1ha2_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint64_t hash = t1ha2_atonce((char*)&input, sizeof(int32_t), 0);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* t1ha2 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha2_int_seed);
+
+Datum
+t1ha2_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    uint64_t hash = t1ha2_atonce((char*)&input, sizeof(int32_t), (uint64_t)seed);
+    PG_RETURN_INT64((int64_t)hash);
+}
+
+/* PostgreSQL function wrappers for t1ha2_128 */
+
+/* t1ha2_128 for text input with default seed - returns array of two bigints */
+PG_FUNCTION_INFO_V1(t1ha2_128_text);
+
+Datum
+t1ha2_128_text(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint128_t hash = t1ha2_atonce128(data, len, 0);
+    
+    Datum result[2];
+    ArrayType *array;
+    
+    result[0] = Int64GetDatum((int64_t)hash.low);
+    result[1] = Int64GetDatum((int64_t)hash.high);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* t1ha2_128 for text input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha2_128_text_seed);
+
+Datum
+t1ha2_128_text_seed(PG_FUNCTION_ARGS)
+{
+    text *input = PG_GETARG_TEXT_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint128_t hash = t1ha2_atonce128(data, len, (uint64_t)seed);
+    
+    Datum result[2];
+    ArrayType *array;
+    
+    result[0] = Int64GetDatum((int64_t)hash.low);
+    result[1] = Int64GetDatum((int64_t)hash.high);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* t1ha2_128 for bytea input with default seed */
+PG_FUNCTION_INFO_V1(t1ha2_128_bytea);
+
+Datum
+t1ha2_128_bytea(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint128_t hash = t1ha2_atonce128(data, len, 0);
+    
+    Datum result[2];
+    ArrayType *array;
+    
+    result[0] = Int64GetDatum((int64_t)hash.low);
+    result[1] = Int64GetDatum((int64_t)hash.high);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* t1ha2_128 for bytea input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha2_128_bytea_seed);
+
+Datum
+t1ha2_128_bytea_seed(PG_FUNCTION_ARGS)
+{
+    bytea *input = PG_GETARG_BYTEA_PP(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    char *data = VARDATA_ANY(input);
+    int len = VARSIZE_ANY_EXHDR(input);
+    uint128_t hash = t1ha2_atonce128(data, len, (uint64_t)seed);
+    
+    Datum result[2];
+    ArrayType *array;
+    
+    result[0] = Int64GetDatum((int64_t)hash.low);
+    result[1] = Int64GetDatum((int64_t)hash.high);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* t1ha2_128 for integer input with default seed */
+PG_FUNCTION_INFO_V1(t1ha2_128_int);
+
+Datum
+t1ha2_128_int(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    uint128_t hash = t1ha2_atonce128((char*)&input, sizeof(int32_t), 0);
+    
+    Datum result[2];
+    ArrayType *array;
+    
+    result[0] = Int64GetDatum((int64_t)hash.low);
+    result[1] = Int64GetDatum((int64_t)hash.high);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}
+
+/* t1ha2_128 for integer input with custom seed */
+PG_FUNCTION_INFO_V1(t1ha2_128_int_seed);
+
+Datum
+t1ha2_128_int_seed(PG_FUNCTION_ARGS)
+{
+    int32_t input = PG_GETARG_INT32(0);
+    int64_t seed = PG_GETARG_INT64(1);
+    uint128_t hash = t1ha2_atonce128((char*)&input, sizeof(int32_t), (uint64_t)seed);
+    
+    Datum result[2];
+    ArrayType *array;
+    
+    result[0] = Int64GetDatum((int64_t)hash.low);
+    result[1] = Int64GetDatum((int64_t)hash.high);
+    
+    array = construct_array(result, 2, INT8OID, 8, true, 'd');
+    PG_RETURN_ARRAYTYPE_P(array);
+}

--- a/tests/expected/t1ha0.out
+++ b/tests/expected/t1ha0.out
@@ -1,0 +1,174 @@
+-- Test basic hash functionality with text
+SELECT t1ha0('hello world');
+        t1ha0         
+----------------------
+ -3982934761687309927
+(1 row)
+
+-- Test hash with different text inputs
+SELECT t1ha0('test string');
+       t1ha0        
+--------------------
+ 673044971507390599
+(1 row)
+
+SELECT t1ha0('another test');
+        t1ha0        
+---------------------
+ 2841094725013662549
+(1 row)
+
+-- Test text input with custom seed
+SELECT t1ha0('hello world', 42);
+        t1ha0        
+---------------------
+ 1279792141742268733
+(1 row)
+
+SELECT t1ha0('hello world', 84);
+        t1ha0         
+----------------------
+ -1418659640464605650
+(1 row)
+
+-- Test bytea input
+SELECT t1ha0('hello world'::bytea);
+        t1ha0         
+----------------------
+ -3982934761687309927
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT t1ha0('hello world'::bytea, 42);
+        t1ha0        
+---------------------
+ 1279792141742268733
+(1 row)
+
+-- Test integer input
+SELECT t1ha0(12345);
+        t1ha0         
+----------------------
+ -8775173509347982182
+(1 row)
+
+SELECT t1ha0(-12345);
+       t1ha0        
+--------------------
+ 467022176890428590
+(1 row)
+
+-- Test integer input with custom seed
+SELECT t1ha0(12345, 42);
+        t1ha0         
+----------------------
+ -4032290342144274562
+(1 row)
+
+SELECT t1ha0(-12345, 84);
+        t1ha0        
+---------------------
+ 3329593101571562488
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha0('consistent test') = t1ha0('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha0('seed test', 1) != t1ha0('seed test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT t1ha0('');
+ t1ha0 
+-------
+     0
+(1 row)
+
+-- Test single character
+SELECT t1ha0('a');
+        t1ha0        
+---------------------
+ 3263157828798237441
+(1 row)
+
+-- Test long string
+SELECT t1ha0('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+        t1ha0         
+----------------------
+ -4769530198040446370
+(1 row)
+
+-- Test various input lengths to test different code paths
+SELECT t1ha0('1234567');           -- 7 bytes
+        t1ha0        
+---------------------
+ -948926565314199635
+(1 row)
+
+SELECT t1ha0('12345678');          -- 8 bytes  
+        t1ha0        
+---------------------
+ -159888592605270680
+(1 row)
+
+SELECT t1ha0('123456789012345');   -- 15 bytes
+        t1ha0        
+---------------------
+ 7271032262454825205
+(1 row)
+
+SELECT t1ha0('1234567890123456');  -- 16 bytes
+        t1ha0         
+----------------------
+ -1909296071942659257
+(1 row)
+
+SELECT t1ha0('12345678901234567890123456789012'); -- 32 bytes
+        t1ha0        
+---------------------
+ 4693993531251190285
+(1 row)
+
+SELECT t1ha0('123456789012345678901234567890123'); -- 33 bytes
+        t1ha0        
+---------------------
+ -360699101541253897
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha0'
+ORDER BY proname, proargtypes;
+ proname | provolatile | proisstrict 
+---------+-------------+-------------
+ t1ha0   | i           | t
+ t1ha0   | i           | t
+ t1ha0   | i           | t
+ t1ha0   | i           | t
+ t1ha0   | i           | t
+ t1ha0   | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/t1ha1.out
+++ b/tests/expected/t1ha1.out
@@ -1,0 +1,174 @@
+-- Test basic hash functionality with text
+SELECT t1ha1('hello world');
+        t1ha1         
+----------------------
+ -3912648815814528862
+(1 row)
+
+-- Test hash with different text inputs
+SELECT t1ha1('test string');
+       t1ha1       
+-------------------
+ 22836396329573165
+(1 row)
+
+SELECT t1ha1('another test');
+        t1ha1        
+---------------------
+ 8532611023766273279
+(1 row)
+
+-- Test text input with custom seed
+SELECT t1ha1('hello world', 42);
+        t1ha1        
+---------------------
+ 6512687883200614590
+(1 row)
+
+SELECT t1ha1('hello world', 84);
+        t1ha1        
+---------------------
+ 8672737372929091947
+(1 row)
+
+-- Test bytea input
+SELECT t1ha1('hello world'::bytea);
+        t1ha1         
+----------------------
+ -3912648815814528862
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT t1ha1('hello world'::bytea, 42);
+        t1ha1        
+---------------------
+ 6512687883200614590
+(1 row)
+
+-- Test integer input
+SELECT t1ha1(12345);
+        t1ha1         
+----------------------
+ -3263203806586990028
+(1 row)
+
+SELECT t1ha1(-12345);
+        t1ha1        
+---------------------
+ 1056465972331175422
+(1 row)
+
+-- Test integer input with custom seed
+SELECT t1ha1(12345, 42);
+        t1ha1         
+----------------------
+ -2965073534604992670
+(1 row)
+
+SELECT t1ha1(-12345, 84);
+        t1ha1        
+---------------------
+ 3994039927196885025
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha1('consistent test') = t1ha1('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha1('seed test', 1) != t1ha1('seed test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT t1ha1('');
+ t1ha1 
+-------
+     0
+(1 row)
+
+-- Test single character
+SELECT t1ha1('a');
+        t1ha1        
+---------------------
+ 1862715155098400308
+(1 row)
+
+-- Test long string
+SELECT t1ha1('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+        t1ha1        
+---------------------
+ 3296404290822654806
+(1 row)
+
+-- Test various input lengths to test different code paths
+SELECT t1ha1('1234567');           -- 7 bytes
+        t1ha1         
+----------------------
+ -5787676341473605757
+(1 row)
+
+SELECT t1ha1('12345678');          -- 8 bytes  
+        t1ha1        
+---------------------
+ 1667129700347281224
+(1 row)
+
+SELECT t1ha1('123456789012345');   -- 15 bytes
+       t1ha1        
+--------------------
+ 774991217029260232
+(1 row)
+
+SELECT t1ha1('1234567890123456');  -- 16 bytes
+        t1ha1         
+----------------------
+ -4841296275810522002
+(1 row)
+
+SELECT t1ha1('12345678901234567890123456789012'); -- 32 bytes
+        t1ha1        
+---------------------
+ 1982017324416562156
+(1 row)
+
+SELECT t1ha1('123456789012345678901234567890123'); -- 33 bytes
+        t1ha1        
+---------------------
+ 1046741975922950024
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha1'
+ORDER BY proname, proargtypes;
+ proname | provolatile | proisstrict 
+---------+-------------+-------------
+ t1ha1   | i           | t
+ t1ha1   | i           | t
+ t1ha1   | i           | t
+ t1ha1   | i           | t
+ t1ha1   | i           | t
+ t1ha1   | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/t1ha2.out
+++ b/tests/expected/t1ha2.out
@@ -1,0 +1,174 @@
+-- Test basic hash functionality with text
+SELECT t1ha2('hello world');
+        t1ha2         
+----------------------
+ -3982934761687309927
+(1 row)
+
+-- Test hash with different text inputs
+SELECT t1ha2('test string');
+       t1ha2        
+--------------------
+ 673044971507390599
+(1 row)
+
+SELECT t1ha2('another test');
+        t1ha2        
+---------------------
+ 2841094725013662549
+(1 row)
+
+-- Test text input with custom seed
+SELECT t1ha2('hello world', 42);
+        t1ha2        
+---------------------
+ 1279792141742268733
+(1 row)
+
+SELECT t1ha2('hello world', 84);
+        t1ha2         
+----------------------
+ -1418659640464605650
+(1 row)
+
+-- Test bytea input
+SELECT t1ha2('hello world'::bytea);
+        t1ha2         
+----------------------
+ -3982934761687309927
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT t1ha2('hello world'::bytea, 42);
+        t1ha2        
+---------------------
+ 1279792141742268733
+(1 row)
+
+-- Test integer input
+SELECT t1ha2(12345);
+        t1ha2         
+----------------------
+ -8775173509347982182
+(1 row)
+
+SELECT t1ha2(-12345);
+       t1ha2        
+--------------------
+ 467022176890428590
+(1 row)
+
+-- Test integer input with custom seed
+SELECT t1ha2(12345, 42);
+        t1ha2         
+----------------------
+ -4032290342144274562
+(1 row)
+
+SELECT t1ha2(-12345, 84);
+        t1ha2        
+---------------------
+ 3329593101571562488
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha2('consistent test') = t1ha2('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha2('seed test', 1) != t1ha2('seed test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT t1ha2('');
+ t1ha2 
+-------
+     0
+(1 row)
+
+-- Test single character
+SELECT t1ha2('a');
+        t1ha2        
+---------------------
+ 3263157828798237441
+(1 row)
+
+-- Test long string
+SELECT t1ha2('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+        t1ha2         
+----------------------
+ -4769530198040446370
+(1 row)
+
+-- Test various input lengths to test different code paths
+SELECT t1ha2('1234567');           -- 7 bytes
+        t1ha2        
+---------------------
+ -948926565314199635
+(1 row)
+
+SELECT t1ha2('12345678');          -- 8 bytes  
+        t1ha2        
+---------------------
+ -159888592605270680
+(1 row)
+
+SELECT t1ha2('123456789012345');   -- 15 bytes
+        t1ha2        
+---------------------
+ 7271032262454825205
+(1 row)
+
+SELECT t1ha2('1234567890123456');  -- 16 bytes
+        t1ha2         
+----------------------
+ -1909296071942659257
+(1 row)
+
+SELECT t1ha2('12345678901234567890123456789012'); -- 32 bytes
+        t1ha2        
+---------------------
+ 4693993531251190285
+(1 row)
+
+SELECT t1ha2('123456789012345678901234567890123'); -- 33 bytes
+        t1ha2        
+---------------------
+ -360699101541253897
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha2'
+ORDER BY proname, proargtypes;
+ proname | provolatile | proisstrict 
+---------+-------------+-------------
+ t1ha2   | i           | t
+ t1ha2   | i           | t
+ t1ha2   | i           | t
+ t1ha2   | i           | t
+ t1ha2   | i           | t
+ t1ha2   | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/expected/t1ha2_128.out
+++ b/tests/expected/t1ha2_128.out
@@ -1,0 +1,183 @@
+-- Test basic hash functionality with text
+SELECT t1ha2_128('hello world');
+                 t1ha2_128                  
+--------------------------------------------
+ {1462807296381820210,-5445742058069130137}
+(1 row)
+
+-- Test hash with different text inputs
+SELECT t1ha2_128('test string');
+                 t1ha2_128                  
+--------------------------------------------
+ {6953955815043936881,-6280910843536546282}
+(1 row)
+
+SELECT t1ha2_128('another test');
+                t1ha2_128                
+-----------------------------------------
+ {47090421500347540,2794004303513315009}
+(1 row)
+
+-- Test text input with custom seed
+SELECT t1ha2_128('hello world', 42);
+                 t1ha2_128                 
+-------------------------------------------
+ {-575494176204213404,1855286317946482137}
+(1 row)
+
+SELECT t1ha2_128('hello world', 84);
+                 t1ha2_128                  
+--------------------------------------------
+ {-6911933389925174446,5493273749460568796}
+(1 row)
+
+-- Test bytea input
+SELECT t1ha2_128('hello world'::bytea);
+                 t1ha2_128                  
+--------------------------------------------
+ {1462807296381820210,-5445742058069130137}
+(1 row)
+
+-- Test bytea input with custom seed
+SELECT t1ha2_128('hello world'::bytea, 42);
+                 t1ha2_128                 
+-------------------------------------------
+ {-575494176204213404,1855286317946482137}
+(1 row)
+
+-- Test integer input
+SELECT t1ha2_128(12345);
+                  t1ha2_128                  
+---------------------------------------------
+ {-3887107517173674402,-4888065992174307780}
+(1 row)
+
+SELECT t1ha2_128(-12345);
+                t1ha2_128                 
+------------------------------------------
+ {901496422677154122,-434474245786725532}
+(1 row)
+
+-- Test integer input with custom seed
+SELECT t1ha2_128(12345, 42);
+                  t1ha2_128                  
+---------------------------------------------
+ {-1836157354982897709,-2196132987161376853}
+(1 row)
+
+SELECT t1ha2_128(-12345, 84);
+                  t1ha2_128                  
+---------------------------------------------
+ {-6004758575032658289,-9112392397105330839}
+(1 row)
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha2_128('consistent test') = t1ha2_128('consistent test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha2_128('seed test', 1) != t1ha2_128('seed test', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test empty string
+SELECT t1ha2_128('');
+ t1ha2_128 
+-----------
+ {0,0}
+(1 row)
+
+-- Test single character
+SELECT t1ha2_128('a');
+                 t1ha2_128                  
+--------------------------------------------
+ {6500011561861736455,-3236853733063499014}
+(1 row)
+
+-- Test long string
+SELECT t1ha2_128('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+                 t1ha2_128                 
+-------------------------------------------
+ {6020166660828880800,7657047214840224446}
+(1 row)
+
+-- Test various input lengths to test different code paths
+SELECT t1ha2_128('1234567');           -- 7 bytes
+                 t1ha2_128                 
+-------------------------------------------
+ {713918099559126361,-1662844664873325996}
+(1 row)
+
+SELECT t1ha2_128('12345678');          -- 8 bytes  
+                 t1ha2_128                  
+--------------------------------------------
+ {6631516098274171640,-6791404690879442320}
+(1 row)
+
+SELECT t1ha2_128('123456789012345');   -- 15 bytes
+                 t1ha2_128                 
+-------------------------------------------
+ {3028575210186940053,4242457052267885152}
+(1 row)
+
+SELECT t1ha2_128('1234567890123456');  -- 16 bytes
+                 t1ha2_128                 
+-------------------------------------------
+ {8535889593104632333,8001558408662260026}
+(1 row)
+
+SELECT t1ha2_128('12345678901234567890123456789012'); -- 32 bytes
+                 t1ha2_128                 
+-------------------------------------------
+ {-304780169492891629,4998773700744081914}
+(1 row)
+
+SELECT t1ha2_128('123456789012345678901234567890123'); -- 33 bytes
+                 t1ha2_128                  
+--------------------------------------------
+ {5647291091212178291,-6007990192753432188}
+(1 row)
+
+-- Test array access (128-bit hash returns array of two bigints)
+SELECT 
+    (t1ha2_128('hello world'))[1] AS first_64_bits,
+    (t1ha2_128('hello world'))[2] AS second_64_bits;
+    first_64_bits    |    second_64_bits    
+---------------------+----------------------
+ 1462807296381820210 | -5445742058069130137
+(1 row)
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha2_128'
+ORDER BY proname, proargtypes;
+  proname  | provolatile | proisstrict 
+-----------+-------------+-------------
+ t1ha2_128 | i           | t
+ t1ha2_128 | i           | t
+ t1ha2_128 | i           | t
+ t1ha2_128 | i           | t
+ t1ha2_128 | i           | t
+ t1ha2_128 | i           | t
+(6 rows)
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';
+ extname | extversion 
+---------+------------
+ hashlib | 0.0.1
+(1 row)
+

--- a/tests/sql/t1ha0.sql
+++ b/tests/sql/t1ha0.sql
@@ -1,0 +1,63 @@
+-- Test basic hash functionality with text
+SELECT t1ha0('hello world');
+
+-- Test hash with different text inputs
+SELECT t1ha0('test string');
+SELECT t1ha0('another test');
+
+-- Test text input with custom seed
+SELECT t1ha0('hello world', 42);
+SELECT t1ha0('hello world', 84);
+
+-- Test bytea input
+SELECT t1ha0('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT t1ha0('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT t1ha0(12345);
+SELECT t1ha0(-12345);
+
+-- Test integer input with custom seed
+SELECT t1ha0(12345, 42);
+SELECT t1ha0(-12345, 84);
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha0('consistent test') = t1ha0('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha0('seed test', 1) != t1ha0('seed test', 2);
+
+-- Test empty string
+SELECT t1ha0('');
+
+-- Test single character
+SELECT t1ha0('a');
+
+-- Test long string
+SELECT t1ha0('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test various input lengths to test different code paths
+SELECT t1ha0('1234567');           -- 7 bytes
+SELECT t1ha0('12345678');          -- 8 bytes  
+SELECT t1ha0('123456789012345');   -- 15 bytes
+SELECT t1ha0('1234567890123456');  -- 16 bytes
+SELECT t1ha0('12345678901234567890123456789012'); -- 32 bytes
+SELECT t1ha0('123456789012345678901234567890123'); -- 33 bytes
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha0'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/t1ha1.sql
+++ b/tests/sql/t1ha1.sql
@@ -1,0 +1,63 @@
+-- Test basic hash functionality with text
+SELECT t1ha1('hello world');
+
+-- Test hash with different text inputs
+SELECT t1ha1('test string');
+SELECT t1ha1('another test');
+
+-- Test text input with custom seed
+SELECT t1ha1('hello world', 42);
+SELECT t1ha1('hello world', 84);
+
+-- Test bytea input
+SELECT t1ha1('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT t1ha1('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT t1ha1(12345);
+SELECT t1ha1(-12345);
+
+-- Test integer input with custom seed
+SELECT t1ha1(12345, 42);
+SELECT t1ha1(-12345, 84);
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha1('consistent test') = t1ha1('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha1('seed test', 1) != t1ha1('seed test', 2);
+
+-- Test empty string
+SELECT t1ha1('');
+
+-- Test single character
+SELECT t1ha1('a');
+
+-- Test long string
+SELECT t1ha1('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test various input lengths to test different code paths
+SELECT t1ha1('1234567');           -- 7 bytes
+SELECT t1ha1('12345678');          -- 8 bytes  
+SELECT t1ha1('123456789012345');   -- 15 bytes
+SELECT t1ha1('1234567890123456');  -- 16 bytes
+SELECT t1ha1('12345678901234567890123456789012'); -- 32 bytes
+SELECT t1ha1('123456789012345678901234567890123'); -- 33 bytes
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha1'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/t1ha2.sql
+++ b/tests/sql/t1ha2.sql
@@ -1,0 +1,63 @@
+-- Test basic hash functionality with text
+SELECT t1ha2('hello world');
+
+-- Test hash with different text inputs
+SELECT t1ha2('test string');
+SELECT t1ha2('another test');
+
+-- Test text input with custom seed
+SELECT t1ha2('hello world', 42);
+SELECT t1ha2('hello world', 84);
+
+-- Test bytea input
+SELECT t1ha2('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT t1ha2('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT t1ha2(12345);
+SELECT t1ha2(-12345);
+
+-- Test integer input with custom seed
+SELECT t1ha2(12345, 42);
+SELECT t1ha2(-12345, 84);
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha2('consistent test') = t1ha2('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha2('seed test', 1) != t1ha2('seed test', 2);
+
+-- Test empty string
+SELECT t1ha2('');
+
+-- Test single character
+SELECT t1ha2('a');
+
+-- Test long string
+SELECT t1ha2('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test various input lengths to test different code paths
+SELECT t1ha2('1234567');           -- 7 bytes
+SELECT t1ha2('12345678');          -- 8 bytes  
+SELECT t1ha2('123456789012345');   -- 15 bytes
+SELECT t1ha2('1234567890123456');  -- 16 bytes
+SELECT t1ha2('12345678901234567890123456789012'); -- 32 bytes
+SELECT t1ha2('123456789012345678901234567890123'); -- 33 bytes
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha2'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';

--- a/tests/sql/t1ha2_128.sql
+++ b/tests/sql/t1ha2_128.sql
@@ -1,0 +1,68 @@
+-- Test basic hash functionality with text
+SELECT t1ha2_128('hello world');
+
+-- Test hash with different text inputs
+SELECT t1ha2_128('test string');
+SELECT t1ha2_128('another test');
+
+-- Test text input with custom seed
+SELECT t1ha2_128('hello world', 42);
+SELECT t1ha2_128('hello world', 84);
+
+-- Test bytea input
+SELECT t1ha2_128('hello world'::bytea);
+
+-- Test bytea input with custom seed
+SELECT t1ha2_128('hello world'::bytea, 42);
+
+-- Test integer input
+SELECT t1ha2_128(12345);
+SELECT t1ha2_128(-12345);
+
+-- Test integer input with custom seed
+SELECT t1ha2_128(12345, 42);
+SELECT t1ha2_128(-12345, 84);
+
+-- Test consistency (same input should give same hash)
+SELECT t1ha2_128('consistent test') = t1ha2_128('consistent test');
+
+-- Test seed effect (same input, different seeds should give different hashes)
+SELECT t1ha2_128('seed test', 1) != t1ha2_128('seed test', 2);
+
+-- Test empty string
+SELECT t1ha2_128('');
+
+-- Test single character
+SELECT t1ha2_128('a');
+
+-- Test long string
+SELECT t1ha2_128('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+
+-- Test various input lengths to test different code paths
+SELECT t1ha2_128('1234567');           -- 7 bytes
+SELECT t1ha2_128('12345678');          -- 8 bytes  
+SELECT t1ha2_128('123456789012345');   -- 15 bytes
+SELECT t1ha2_128('1234567890123456');  -- 16 bytes
+SELECT t1ha2_128('12345678901234567890123456789012'); -- 32 bytes
+SELECT t1ha2_128('123456789012345678901234567890123'); -- 33 bytes
+
+-- Test array access (128-bit hash returns array of two bigints)
+SELECT 
+    (t1ha2_128('hello world'))[1] AS first_64_bits,
+    (t1ha2_128('hello world'))[2] AS second_64_bits;
+
+-- Test function properties
+SELECT 
+    proname,
+    provolatile,
+    proisstrict
+FROM pg_proc 
+WHERE proname = 't1ha2_128'
+ORDER BY proname, proargtypes;
+
+-- Test extension metadata
+SELECT 
+    extname,
+    extversion
+FROM pg_extension 
+WHERE extname = 'hashlib';


### PR DESCRIPTION
Add t1ha hash functions (t1ha0, t1ha1, t1ha2, t1ha2_128) to hashlib extension with support for text, bytea, and integer inputs; update README to include new algorithm details and usage examples